### PR TITLE
Carmen feature 5 delete plant

### DIFF
--- a/components/Modal/index.js
+++ b/components/Modal/index.js
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import styled from "styled-components";
 
-export default function Modal({ name, id, handleDeletePlant }) {
+export default function Modal({ modalMessage, buttonText, handleButtonFunction  }) {
   const [showModal, setShowModal] = useState(false);
 
   function handleToggleModal() {
@@ -11,22 +11,19 @@ export default function Modal({ name, id, handleDeletePlant }) {
   return (
     <>
       <StyledButton type="button" onClick={handleToggleModal}>
-        Delete Plant
+        {buttonText}
       </StyledButton>
 
       {showModal && (
         <StyledModalBackground>
           <StyledModal>
-            <p>
-              Do you really want to delete{" "}
-              <StyledPlantName>{name}</StyledPlantName>?
-            </p>
+              {modalMessage}
             <StyledModalButtonContainer>
               <StyledButton type="button" onClick={handleToggleModal}>
                 Cancel
               </StyledButton>
-              <StyledButton type="button" onClick={() => handleDeletePlant(id)}>
-                Delete
+              <StyledButton type="button" onClick={handleButtonFunction}>
+                {buttonText}
               </StyledButton>
             </StyledModalButtonContainer>
           </StyledModal>
@@ -75,6 +72,3 @@ const StyledButton = styled.button`
   border-radius: 20px;
 `;
 
-const StyledPlantName = styled.span`
-  font-weight: bold;
-`;

--- a/components/Modal/index.js
+++ b/components/Modal/index.js
@@ -1,0 +1,80 @@
+import { useState } from "react";
+import styled from "styled-components";
+
+export default function Modal({ name, id, handleDeletePlant }) {
+  const [showModal, setShowModal] = useState(false);
+
+  function handleToggleModal() {
+    setShowModal(!showModal);
+  }
+
+  return (
+    <>
+      <StyledButton type="button" onClick={handleToggleModal}>
+        Delete Plant
+      </StyledButton>
+
+      {showModal && (
+        <StyledModalBackground>
+          <StyledModal>
+            <p>
+              Do you really want to delete{" "}
+              <StyledPlantName>{name}</StyledPlantName>?
+            </p>
+            <StyledModalButtonContainer>
+              <StyledButton type="button" onClick={handleToggleModal}>
+                Cancel
+              </StyledButton>
+              <StyledButton type="button" onClick={() => handleDeletePlant(id)}>
+                Delete
+              </StyledButton>
+            </StyledModalButtonContainer>
+          </StyledModal>
+        </StyledModalBackground>
+      )}
+    </>
+  );
+}
+
+const StyledModalBackground = styled.section`
+  background-color: rgba(0, 0, 0, 0.5);
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+`;
+
+const StyledModal = styled.section`
+  background-color: var(--white);
+  border-radius: 35px;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 80%;
+  height: 40%;
+  padding: 0 20px;
+  display: flex;
+  text-align: center;
+  flex-direction: column;
+  justify-content: center;
+  gap: 10px;
+`;
+
+const StyledModalButtonContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+`;
+
+const StyledButton = styled.button`
+  background-color: var(--brown);
+  padding: 8px 20px;
+  border: none;
+  border-radius: 20px;
+`;
+
+const StyledPlantName = styled.span`
+  font-weight: bold;
+`;

--- a/components/PlantDeleteButton/index.js
+++ b/components/PlantDeleteButton/index.js
@@ -9,6 +9,10 @@ function handleToggle() {
 
 
 
+// if(plants.length === 0) {
+//     show info text that list is empty
+//     render Add plant button
+// }
 
 
 

--- a/components/PlantDeleteButton/index.js
+++ b/components/PlantDeleteButton/index.js
@@ -1,75 +1,9 @@
-import { useState } from "react"
-import styled from "styled-components";
+import Modal from "../Modal";
 
-export default function PlantDeleteButton({ name, id, handleDeletePlant }) {
-const [showDeleteModal, setShowDeleteModal] = useState(false);
+export default function PlantDeleteButton({ onDeletePlant, name, id }) {
+  const Info = "Do you really want to delete {name}?";
 
-function handleToggleModal() {
-    setShowDeleteModal(!showDeleteModal);
-};
-
-return (
-    <>
-    <StyledButton type="button" onClick={handleToggleModal}>Delete Plant</StyledButton>
-
-    {showDeleteModal &&
-        <StyledDeleteModalBackground>
-            <StyledDeleteModal>
-                <p>Do you really want to delete <StyledPlantName>{name}</StyledPlantName>?</p>
-                <StyledDeleteModalButtonContainer>
-                    <StyledButton type="button" onClick={handleToggleModal}>Cancel</StyledButton>
-                    <StyledButton type="button" onClick={() => handleDeletePlant(id)}>Delete</StyledButton>
-                </StyledDeleteModalButtonContainer>
-            </StyledDeleteModal>
-        </StyledDeleteModalBackground>
-    }
-    </>
-)
-
-};
-
-
-const StyledDeleteModalBackground = styled.section`
-    background-color: rgba(0, 0, 0, 0.5);
-    position: fixed;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-`;
-
-const StyledDeleteModal = styled.section`
-    background-color: var(--white);
-    border-radius: 35px;
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    width: 80%;
-    height: 40%;
-    padding: 0 20px;
-    display: flex;
-    text-align: center;
-    flex-direction: column;
-    justify-content: center;
-    gap: 10px;
-`;
-
-const StyledDeleteModalButtonContainer = styled.div`
-    display: flex;
-    justify-content: center;
-    gap: 10px;
-
-`;
-
-const StyledButton = styled.button`
-    background-color: var(--brown);
-    padding: 8px 20px;
-    border: none;
-    border-radius: 20px;
-`;
-
-
-const StyledPlantName = styled.span`
-    font-weight: bold;
-`;
+  return (
+    <Modal handleDeletePlant={onDeletePlant} name={name} id={id} Info={Info} />
+  );
+}

--- a/components/PlantDeleteButton/index.js
+++ b/components/PlantDeleteButton/index.js
@@ -1,23 +1,26 @@
 import { useState } from "react"
 
-export default function PlantDeleteButton() {
+export default function PlantDeleteButton({ handleDeletePlant }) {
 const [showDeleteModal, setShowDeleteModal] = useState(false);
 
-function handleDelete() {
+function handleToggle() {
     setShowDeleteModal(!showDeleteModal);
+};
 
 
 
-}
 
 
 
 return(
     <>
-    <button type="button" onClick={handleDelete}>Delete Plant</button>
+    <button type="button" onClick={handleToggle}>Delete Plant</button>
 
     {showDeleteModal === true ? (
-        <button type="button">Cancel</button>
+        <>
+            <button type="button" onClick={handleToggle}>Cancel</button>
+            <button type="button" onClick={handleDeletePlant}>Delete</button>
+        </>
     ) : null
     }
     </>

--- a/components/PlantDeleteButton/index.js
+++ b/components/PlantDeleteButton/index.js
@@ -1,9 +1,26 @@
 import Modal from "../Modal";
+import styled from "styled-components";
 
 export default function PlantDeleteButton({ onDeletePlant, name, id }) {
-  const Info = "Do you really want to delete {name}?";
+  const deletionConfirmText = (
+    <p>
+      Do you really want to delete <StyledPlantName>{name}</StyledPlantName>?
+    </p>
+  );
+
+  const deleteButtonText = "Delete Plant";
+
 
   return (
-    <Modal handleDeletePlant={onDeletePlant} name={name} id={id} Info={Info} />
+    <Modal 
+    modalMessage={deletionConfirmText}
+    buttonText={deleteButtonText}
+    handleButtonFunction={() => onDeletePlant(id)}
+     />
   );
 }
+
+
+const StyledPlantName = styled.span`
+  font-weight: bold;
+`;

--- a/components/PlantDeleteButton/index.js
+++ b/components/PlantDeleteButton/index.js
@@ -1,7 +1,7 @@
 import { useState } from "react"
 import styled from "styled-components";
 
-export default function PlantDeleteButton({ id, handleDeletePlant }) {
+export default function PlantDeleteButton({ name, id, handleDeletePlant }) {
 const [showDeleteModal, setShowDeleteModal] = useState(false);
 
 function handleToggleModal() {
@@ -14,13 +14,15 @@ return(
     <StyledButton type="button" onClick={handleToggleModal}>Delete Plant</StyledButton>
 
     {showDeleteModal === true ? (
-        <StyledDeleteModal>
-            <p>Are you sure you want to delete PLANTNAME?</p>
-            <StyledDeleteModalButtonContainer>
-                <button type="button" onClick={handleToggleModal}>Cancel</button>
-                <button type="button" onClick={() => handleDeletePlant(id)}>Delete</button>
-            </StyledDeleteModalButtonContainer>
-        </StyledDeleteModal>
+        <StyledDeleteModalBackground>
+            <StyledDeleteModal>
+                <p>Do you really want to delete <StyledPlantName>{name}</StyledPlantName>?</p>
+                <StyledDeleteModalButtonContainer>
+                    <StyledButton type="button" onClick={handleToggleModal}>Cancel</StyledButton>
+                    <StyledButton type="button" onClick={() => handleDeletePlant(id)}>Delete</StyledButton>
+                </StyledDeleteModalButtonContainer>
+            </StyledDeleteModal>
+        </StyledDeleteModalBackground>
     ) : null
     }
     </>
@@ -29,33 +31,33 @@ return(
 };
 
 
+const StyledDeleteModalBackground = styled.section`
+    content: "";
+    background-color: rgba(0, 0, 0, 0.5);
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 100;
+`;
+
 const StyledDeleteModal = styled.section`
-    background-color: rgba(128, 128, 128, 0.6);
+    background-color: var(--white);
+    border-radius: 35px;
     position: fixed;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
     width: 80%;
     height: 40%;
-    border-radius: 35px;
+    padding: 0 20px;
     display: flex;
     text-align: center;
     flex-direction: column;
     justify-content: center;
     gap: 10px;
     z-index: 110;
-
-    /* :before {
-        content: "";
-        background-color: rgba(128, 128, 128, 0.3);
-        position: fixed;
-        top: 0;
-        bottom: 0;
-        left: 0;
-        right: 0;
-        z-index: 100;
-    }; */
-
 `;
 
 const StyledDeleteModalButtonContainer = styled.div`
@@ -65,12 +67,14 @@ const StyledDeleteModalButtonContainer = styled.div`
 
 `;
 
-
 const StyledButton = styled.button`
     background-color: var(--brown);
-    padding: 5px;
+    padding: 8px;
     border: none;
-    border-radius: 10px;
+    border-radius: 20px;
 `;
 
-//aside, section as alternative to div
+
+const StyledPlantName = styled.span`
+    font-weight: bold;
+`;

--- a/components/PlantDeleteButton/index.js
+++ b/components/PlantDeleteButton/index.js
@@ -1,33 +1,76 @@
 import { useState } from "react"
+import styled from "styled-components";
 
 export default function PlantDeleteButton({ id, handleDeletePlant }) {
 const [showDeleteModal, setShowDeleteModal] = useState(false);
 
-function handleToggle() {
+function handleToggleModal() {
     setShowDeleteModal(!showDeleteModal);
 };
 
 
-
-// if(plants.length === 0) {
-//     show info text that list is empty
-//     render Add plant button
-// }
-
-
-
 return(
     <>
-    <button type="button" onClick={handleToggle}>Delete Plant</button>
+    <StyledButton type="button" onClick={handleToggleModal}>Delete Plant</StyledButton>
 
     {showDeleteModal === true ? (
-        <>
-            <button type="button" onClick={handleToggle}>Cancel</button>
-            <button type="button" onClick={() => handleDeletePlant(id)}>Delete</button>
-        </>
+        <StyledDeleteModal>
+            <p>Are you sure you want to delete PLANTNAME?</p>
+            <StyledDeleteModalButtonContainer>
+                <button type="button" onClick={handleToggleModal}>Cancel</button>
+                <button type="button" onClick={() => handleDeletePlant(id)}>Delete</button>
+            </StyledDeleteModalButtonContainer>
+        </StyledDeleteModal>
     ) : null
     }
     </>
 )
 
 };
+
+
+const StyledDeleteModal = styled.section`
+    background-color: rgba(128, 128, 128, 0.6);
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 80%;
+    height: 40%;
+    border-radius: 35px;
+    display: flex;
+    text-align: center;
+    flex-direction: column;
+    justify-content: center;
+    gap: 10px;
+    z-index: 110;
+
+    /* :before {
+        content: "";
+        background-color: rgba(128, 128, 128, 0.3);
+        position: fixed;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        z-index: 100;
+    }; */
+
+`;
+
+const StyledDeleteModalButtonContainer = styled.div`
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+
+`;
+
+
+const StyledButton = styled.button`
+    background-color: var(--brown);
+    padding: 5px;
+    border: none;
+    border-radius: 10px;
+`;
+
+//aside, section as alternative to div

--- a/components/PlantDeleteButton/index.js
+++ b/components/PlantDeleteButton/index.js
@@ -12,7 +12,7 @@ return (
     <>
     <StyledButton type="button" onClick={handleToggleModal}>Delete Plant</StyledButton>
 
-    {showDeleteModal === true ? (
+    {showDeleteModal &&
         <StyledDeleteModalBackground>
             <StyledDeleteModal>
                 <p>Do you really want to delete <StyledPlantName>{name}</StyledPlantName>?</p>
@@ -22,7 +22,6 @@ return (
                 </StyledDeleteModalButtonContainer>
             </StyledDeleteModal>
         </StyledDeleteModalBackground>
-    ) : null
     }
     </>
 )
@@ -31,7 +30,6 @@ return (
 
 
 const StyledDeleteModalBackground = styled.section`
-    content: "";
     background-color: rgba(0, 0, 0, 0.5);
     position: fixed;
     top: 0;

--- a/components/PlantDeleteButton/index.js
+++ b/components/PlantDeleteButton/index.js
@@ -1,0 +1,26 @@
+import { useState } from "react"
+
+export default function PlantDeleteButton() {
+const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+function handleDelete() {
+    setShowDeleteModal(!showDeleteModal);
+
+
+
+}
+
+
+
+return(
+    <>
+    <button type="button" onClick={handleDelete}>Delete Plant</button>
+
+    {showDeleteModal === true ? (
+        <button type="button">Cancel</button>
+    ) : null
+    }
+    </>
+)
+
+};

--- a/components/PlantDeleteButton/index.js
+++ b/components/PlantDeleteButton/index.js
@@ -1,6 +1,6 @@
 import { useState } from "react"
 
-export default function PlantDeleteButton({ handleDeletePlant }) {
+export default function PlantDeleteButton({ id, handleDeletePlant }) {
 const [showDeleteModal, setShowDeleteModal] = useState(false);
 
 function handleToggle() {
@@ -19,7 +19,7 @@ return(
     {showDeleteModal === true ? (
         <>
             <button type="button" onClick={handleToggle}>Cancel</button>
-            <button type="button" onClick={handleDeletePlant}>Delete</button>
+            <button type="button" onClick={() => handleDeletePlant(id)}>Delete</button>
         </>
     ) : null
     }

--- a/components/PlantDeleteButton/index.js
+++ b/components/PlantDeleteButton/index.js
@@ -8,8 +8,7 @@ function handleToggleModal() {
     setShowDeleteModal(!showDeleteModal);
 };
 
-
-return(
+return (
     <>
     <StyledButton type="button" onClick={handleToggleModal}>Delete Plant</StyledButton>
 
@@ -39,7 +38,6 @@ const StyledDeleteModalBackground = styled.section`
     bottom: 0;
     left: 0;
     right: 0;
-    z-index: 100;
 `;
 
 const StyledDeleteModal = styled.section`
@@ -57,7 +55,6 @@ const StyledDeleteModal = styled.section`
     flex-direction: column;
     justify-content: center;
     gap: 10px;
-    z-index: 110;
 `;
 
 const StyledDeleteModalButtonContainer = styled.div`
@@ -69,7 +66,7 @@ const StyledDeleteModalButtonContainer = styled.div`
 
 const StyledButton = styled.button`
     background-color: var(--brown);
-    padding: 8px;
+    padding: 8px 20px;
     border: none;
     border-radius: 20px;
 `;

--- a/components/PlantDetails/PlantDetails.js
+++ b/components/PlantDetails/PlantDetails.js
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import { LuDroplet } from "react-icons/lu";
 import { FiSun } from "react-icons/fi";
 import Link from "next/link";
-import PlantDeleteButton from "../Modal";
+import PlantDeleteButton from "../PlantDeleteButton";
 
 export default function PlantDetails({
   name,

--- a/components/PlantDetails/PlantDetails.js
+++ b/components/PlantDetails/PlantDetails.js
@@ -75,7 +75,7 @@ export default function PlantDetails({
           <br />
         </StyledPlantNeedsContainer>
         <StyledImageContainer>
-          <Image src={imageUrl} alt={name} width={300} height={300} />
+          <StyledImage src={imageUrl} alt={name} fill={true} />
         </StyledImageContainer>
       </StyledPlantContainer>
       <h4>Description:</h4>
@@ -111,15 +111,23 @@ const StyledPlantContainer = styled.section`
   margin: 25px;
 `;
 
+const StyledPlantNeedsContainer = styled.article`
+  display: flex;
+  flex-direction: column;
+`;
+
 const StyledImageContainer = styled.div`
   width: 300px;
   height: 300px;
   overflow: hidden;
-  display: flex;
-  justify-content: center;
+  position: relative;
+  margin-bottom: 15px;
 `;
 
-const StyledPlantNeedsContainer = styled.article`
-  display: flex;
-  flex-direction: column;
+const StyledImage = styled(Image)`
+  width: 200%;
+  height: auto;
+  text-align: center;
+  border-radius: 35px;
+  object-fit: cover;
 `;

--- a/components/PlantDetails/PlantDetails.js
+++ b/components/PlantDetails/PlantDetails.js
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import { LuDroplet } from "react-icons/lu";
 import { FiSun } from "react-icons/fi";
 import Link from "next/link";
+import PlantDeleteButton from "../PlantDeleteButton";
 
 export default function PlantDetails({
   name,
@@ -80,6 +81,8 @@ export default function PlantDetails({
       </StyledPlantContainer>
       <h4>Description:</h4>
       <p>{description}</p>
+      <br />
+      <PlantDeleteButton />
       <br />
       <Link href={"/"}>Homepage</Link>
     </>

--- a/components/PlantDetails/PlantDetails.js
+++ b/components/PlantDetails/PlantDetails.js
@@ -78,7 +78,7 @@ export default function PlantDetails({
           <br />
         </StyledPlantNeedsContainer>
         <StyledImageContainer>
-          <StyledImage src={imageUrl} alt={name} fill={true} />
+          <StyledImage src={imageUrl} alt={name} fill />
         </StyledImageContainer>
       </StyledPlantContainer>
       <h4>Description:</h4>
@@ -86,7 +86,7 @@ export default function PlantDetails({
       <br />
       <PlantDeleteButton handleDeletePlant={onDeletePlant} name={name} id={id}  />
       <br />
-      <Link href={"/"}>Homepage</Link>
+      <Link href="/">Homepage</Link>
     </>
   );
 }

--- a/components/PlantDetails/PlantDetails.js
+++ b/components/PlantDetails/PlantDetails.js
@@ -13,7 +13,8 @@ export default function PlantDetails({
   lightNeed,
   fertiliserSeason,
   description,
-  onDeletePlant
+  onDeletePlant,
+  id
 }) {
   return (
     <>
@@ -83,7 +84,7 @@ export default function PlantDetails({
       <h4>Description:</h4>
       <p>{description}</p>
       <br />
-      <PlantDeleteButton handleDeletePlant={onDeletePlant} />
+      <PlantDeleteButton handleDeletePlant={onDeletePlant} id={id} />
       <br />
       <Link href={"/"}>Homepage</Link>
     </>

--- a/components/PlantDetails/PlantDetails.js
+++ b/components/PlantDetails/PlantDetails.js
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import { LuDroplet } from "react-icons/lu";
 import { FiSun } from "react-icons/fi";
 import Link from "next/link";
-import PlantDeleteButton from "../PlantDeleteButton";
+import PlantDeleteButton from "../Modal";
 
 export default function PlantDetails({
   name,
@@ -84,7 +84,7 @@ export default function PlantDetails({
       <h4>Description:</h4>
       <p>{description}</p>
       <br />
-      <PlantDeleteButton handleDeletePlant={onDeletePlant} name={name} id={id}  />
+      <PlantDeleteButton onDeletePlant={onDeletePlant} name={name} id={id}  />
       <br />
       <Link href="/">Homepage</Link>
     </>

--- a/components/PlantDetails/PlantDetails.js
+++ b/components/PlantDetails/PlantDetails.js
@@ -84,7 +84,7 @@ export default function PlantDetails({
       <h4>Description:</h4>
       <p>{description}</p>
       <br />
-      <PlantDeleteButton handleDeletePlant={onDeletePlant} id={id} />
+      <PlantDeleteButton handleDeletePlant={onDeletePlant} name={name} id={id}  />
       <br />
       <Link href={"/"}>Homepage</Link>
     </>

--- a/components/PlantDetails/PlantDetails.js
+++ b/components/PlantDetails/PlantDetails.js
@@ -13,6 +13,7 @@ export default function PlantDetails({
   lightNeed,
   fertiliserSeason,
   description,
+  onDeletePlant
 }) {
   return (
     <>
@@ -82,7 +83,7 @@ export default function PlantDetails({
       <h4>Description:</h4>
       <p>{description}</p>
       <br />
-      <PlantDeleteButton />
+      <PlantDeleteButton handleDeletePlant={onDeletePlant} />
       <br />
       <Link href={"/"}>Homepage</Link>
     </>

--- a/lib/data.js
+++ b/lib/data.js
@@ -11,352 +11,352 @@ export const plants = [
     description:
       "The Snake Plant, also known as Mother-in-Law's Tongue, is a hardy and low-maintenance plant that can thrive in low light and requires minimal watering.",
   },
-  // {
-  //   id: "2",
-  //   name: "Fiddle Leaf Fig",
-  //   botanicalName: "Ficus lyrata",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1498766707495-856f300a5821?q=80&w=2971&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Medium",
-  //   lightNeed: "Full Sun",
-  //   fertiliserSeason: ["Spring"],
-  //   description:
-  //     "The Fiddle Leaf Fig is a popular indoor tree known for its large, violin-shaped leaves. It prefers bright, indirect light and consistent watering.",
-  // },
-  // {
-  //   id: "3",
-  //   name: "Aloe Vera",
-  //   botanicalName: "Aloe barbadensis miller",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1702416062979-dc44baa952c1?q=80&w=2970&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Low",
-  //   lightNeed: "Full Sun",
-  //   fertiliserSeason: ["Summer"],
-  //   description:
-  //     "Aloe Vera is a succulent plant species known for its medicinal properties. It requires bright light and minimal water, making it easy to care for.",
-  // },
-  // {
-  //   id: "4",
-  //   name: "Spider Plant",
-  //   botanicalName: "Chlorophytum comosum",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1607363380021-9f1cce0cde24?q=80&w=2970&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Low",
-  //   lightNeed: "Partial Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "The Spider Plant is a resilient houseplant known for its air-purifying qualities and ability to thrive in a variety of light conditions.",
-  // },
-  // {
-  //   id: "5",
-  //   name: "Peace Lily",
-  //   botanicalName: "Spathiphyllum",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1629811119888-dde7186c1fb5?q=80&w=2874&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "High",
-  //   lightNeed: "Full Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "Peace Lilies are known for their beautiful white flowers and ability to thrive in low light. They require frequent watering to maintain their lush foliage.",
-  // },
-  // {
-  //   id: "6",
-  //   name: "Rubber Plant",
-  //   botanicalName: "Ficus elastica",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1643227565928-0cc454ec4937?q=80&w=2874&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Medium",
-  //   lightNeed: "Partial Shade",
-  //   fertiliserSeason: ["Spring", "Fall"],
-  //   description:
-  //     "The Rubber Plant is a popular indoor tree with large, glossy leaves. It thrives in medium to bright light and needs regular watering.",
-  // },
-  // {
-  //   id: "7",
-  //   name: "ZZ Plant",
-  //   botanicalName: "Zamioculcas zamiifolia",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1536882240095-0379873feb4e?q=80&w=2971&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Low",
-  //   lightNeed: "Partial Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "The ZZ Plant is a hardy and drought-tolerant plant that can survive in low light and requires minimal watering, making it perfect for beginners.",
-  // },
-  // {
-  //   id: "8",
-  //   name: "Monstera Deliciosa",
-  //   botanicalName: "Monstera deliciosa",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1545165375-1b744b9ed444?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Medium",
-  //   lightNeed: "Partial Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "Monstera Deliciosa, also known as the Swiss Cheese Plant, is famous for its large, split leaves. It prefers indirect light and moderate watering.",
-  // },
-  // {
-  //   id: "9",
-  //   name: "Pothos",
-  //   botanicalName: "Epipremnum aureum",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1598880940080-ff9a29891b85?q=80&w=1528&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Low",
-  //   lightNeed: "Partial Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "Pothos is a versatile and low-maintenance plant that can thrive in low light and requires infrequent watering. It's known for its trailing vines.",
-  // },
-  // {
-  //   id: "10",
-  //   name: "Boston Fern",
-  //   botanicalName: "Nephrolepis exaltata",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1619398221730-09294c6d4139?q=80&w=1587&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "High",
-  //   lightNeed: "Partial Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "Boston Ferns are lush, green plants that thrive in humid environments with bright, indirect light. They need regular watering to keep their fronds healthy.",
-  // },
-  // {
-  //   id: "11",
-  //   name: "Orchid",
-  //   botanicalName: "Orchidaceae",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1454262041357-5d96f50a2f27?q=80&w=1469&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Low",
-  //   lightNeed: "Partial Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "Orchids are elegant flowering plants that prefer bright, indirect light and minimal watering. They are known for their beautiful and long-lasting blooms.",
-  // },
-  // {
-  //   id: "12",
-  //   name: "Jade Plant",
-  //   botanicalName: "Crassula ovata",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1620127620051-fea30e50c66e?q=80&w=1528&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Low",
-  //   lightNeed: "Full Sun",
-  //   fertiliserSeason: ["Spring", "Fall"],
-  //   description:
-  //     "The Jade Plant is a succulent known for its thick, fleshy leaves. It thrives in bright light and requires minimal watering, making it easy to care for.",
-  // },
-  // {
-  //   id: "13",
-  //   name: "Philodendron",
-  //   botanicalName: "Philodendron spp.",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1675678964961-4c04733ee34a?q=80&w=1528&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Medium",
-  //   lightNeed: "Partial Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "Philodendrons are popular houseplants known for their heart-shaped leaves. They prefer indirect light and consistent watering.",
-  // },
-  // {
-  //   id: "14",
-  //   name: "Cactus",
-  //   botanicalName: "Cactaceae",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1497214068716-571605b05ca8?q=80&w=1471&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Low",
-  //   lightNeed: "Full Sun",
-  //   fertiliserSeason: ["Summer"],
-  //   description:
-  //     "Cacti are desert plants that thrive in bright light and require very little water. They are known for their unique shapes and spines.",
-  // },
-  // {
-  //   id: "15",
-  //   name: "Lavender",
-  //   botanicalName: "Lavandula",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1592685776885-97a964ad8293?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Low",
-  //   lightNeed: "Full Sun",
-  //   fertiliserSeason: ["Spring"],
-  //   description:
-  //     "Lavender is a fragrant herb known for its purple flowers and soothing scent. It requires full sun and minimal watering.",
-  // },
-  // {
-  //   id: "16",
-  //   name: "Succulent",
-  //   botanicalName: "Succulents",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1509069575671-3df40ce5307c?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Low",
-  //   lightNeed: "Full Sun",
-  //   fertiliserSeason: ["Summer", "Fall"],
-  //   description:
-  //     "Succulents are a diverse group of plants known for their water-storing capabilities. They thrive in bright light and require minimal watering.",
-  // },
-  // {
-  //   id: "17",
-  //   name: "Calathea",
-  //   botanicalName: "Calathea spp.",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1602879946327-8b4a148c367d?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "High",
-  //   lightNeed: "Full Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "Calatheas are known for their stunning, patterned leaves. They thrive in low light and high humidity, requiring regular watering to keep their foliage vibrant.",
-  // },
-  // {
-  //   id: "18",
-  //   name: "Yucca",
-  //   botanicalName: "Yucca",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1629516676153-26a76b83701f?q=80&w=1480&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Low",
-  //   lightNeed: "Full Sun",
-  //   fertiliserSeason: ["Spring"],
-  //   description:
-  //     "Yucca plants are hardy and drought-tolerant, known for their long, sword-shaped leaves. They thrive in bright light and require minimal watering.",
-  // },
-  // {
-  //   id: "19",
-  //   name: "Bamboo",
-  //   botanicalName: "Bambusoideae",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1426020744253-568cd6345e93?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Medium",
-  //   lightNeed: "Full Sun",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "Bamboo plants are fast-growing and known for their tall, graceful stalks. They prefer bright light and consistent watering, especially during the growing season.",
-  // },
-  // {
-  //   id: "20",
-  //   name: "Anthurium",
-  //   botanicalName: "Anthurium",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1632906379687-355e24798632?q=80&w=1973&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Medium",
-  //   lightNeed: "Partial Shade",
-  //   fertiliserSeason: ["Spring", "Fall"],
-  //   description:
-  //     "Anthuriums are known for their striking, heart-shaped flowers and glossy leaves. They prefer bright, indirect light and moderate watering.",
-  // },
-  // {
-  //   id: "21",
-  //   name: "English Ivy",
-  //   botanicalName: "Hedera helix",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1724723942347-b113f0cd4a67?q=80&w=2072&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Medium",
-  //   lightNeed: "Full Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "English Ivy is a versatile plant known for its trailing vines and ability to thrive in shaded areas. It requires moderate watering.",
-  // },
-  // {
-  //   id: "22",
-  //   name: "Dumb Cane",
-  //   botanicalName: "Dieffenbachia",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1631556941887-f81ab0ecfda9?q=80&w=1960&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "High",
-  //   lightNeed: "Partial Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "Dumb Cane is a popular houseplant known for its large, variegated leaves. It prefers indirect light and regular watering.",
-  // },
-  // {
-  //   id: "23",
-  //   name: "Golden Pothos",
-  //   botanicalName: "Epipremnum aureum",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1674482918961-57a3a0484bf3?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Low",
-  //   lightNeed: "Partial Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "Golden Pothos is a low-maintenance plant that can thrive in low light and requires infrequent watering. It's known for its trailing vines.",
-  // },
-  // {
-  //   id: "24",
-  //   name: "Peace Lily",
-  //   botanicalName: "Spathiphyllum",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1616694547693-b0f829a6cf30?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8UGVhY2UlMjBMaWx5fGVufDB8MHwwfHx8Mg%3D%3D",
-  //   waterNeed: "High",
-  //   lightNeed: "Full Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "Peace Lilies are known for their beautiful white flowers and ability to thrive in low light. They require frequent watering to maintain their lush foliage.",
-  // },
-  // {
-  //   id: "25",
-  //   name: "Areca Palm",
-  //   botanicalName: "Dypsis lutescens",
-  //   imageUrl:
-  //     "https://images.pexels.com/photos/5538833/pexels-photo-5538833.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1",
-  //   waterNeed: "Medium",
-  //   lightNeed: "Partial Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "Areca Palms are popular indoor palms known for their feathery, arching fronds. They prefer indirect light and regular watering.",
-  // },
-  // {
-  //   id: "26",
-  //   name: "Swiss Cheese Plant",
-  //   botanicalName: "Monstera adansonii",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1604066538249-f3767aa55545?q=80&w=2074&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Medium",
-  //   lightNeed: "Partial Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "The Swiss Cheese Plant is known for its unique, perforated leaves. It prefers bright, indirect light and moderate watering.",
-  // },
-  // {
-  //   id: "27",
-  //   name: "Chinese Money Plant",
-  //   botanicalName: "Pilea peperomioides",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1723650879990-dae890387cff?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Low",
-  //   lightNeed: "Partial Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "The Chinese Money Plant is a trendy houseplant known for its round, coin-shaped leaves. It thrives in bright, indirect light and requires minimal watering.",
-  // },
-  // {
-  //   id: "28",
-  //   name: "Bird of Paradise",
-  //   botanicalName: "Strelitzia reginae",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1591484599836-a9548b9ebbc8?q=80&w=2031&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "High",
-  //   lightNeed: "Full Sun",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "Bird of Paradise is known for its striking, tropical flowers. It requires bright light and regular watering to thrive.",
-  // },
-  // {
-  //   id: "29",
-  //   name: "Jade Plant",
-  //   botanicalName: "Crassula ovata",
-  //   imageUrl:
-  //     "https://images.pexels.com/photos/8507297/pexels-photo-8507297.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1",
-  //   waterNeed: "Low",
-  //   lightNeed: "Full Sun",
-  //   fertiliserSeason: ["Spring", "Fall"],
-  //   description:
-  //     "The Jade Plant is a succulent known for its thick, fleshy leaves. It thrives in bright light and requires minimal watering, making it easy to care for.",
-  // },
-  // {
-  //   id: "30",
-  //   name: "African Violet",
-  //   botanicalName: "Saintpaulia",
-  //   imageUrl:
-  //     "https://images.pexels.com/photos/5706695/pexels-photo-5706695.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1",
-  //   waterNeed: "Medium",
-  //   lightNeed: "Partial Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "African Violets are popular indoor flowering plants known for their vibrant, velvety flowers. They prefer indirect light and moderate watering.",
-  // },
+  {
+    id: "2",
+    name: "Fiddle Leaf Fig",
+    botanicalName: "Ficus lyrata",
+    imageUrl:
+      "https://images.unsplash.com/photo-1498766707495-856f300a5821?q=80&w=2971&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Medium",
+    lightNeed: "Full Sun",
+    fertiliserSeason: ["Spring"],
+    description:
+      "The Fiddle Leaf Fig is a popular indoor tree known for its large, violin-shaped leaves. It prefers bright, indirect light and consistent watering.",
+  },
+  {
+    id: "3",
+    name: "Aloe Vera",
+    botanicalName: "Aloe barbadensis miller",
+    imageUrl:
+      "https://images.unsplash.com/photo-1702416062979-dc44baa952c1?q=80&w=2970&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Low",
+    lightNeed: "Full Sun",
+    fertiliserSeason: ["Summer"],
+    description:
+      "Aloe Vera is a succulent plant species known for its medicinal properties. It requires bright light and minimal water, making it easy to care for.",
+  },
+  {
+    id: "4",
+    name: "Spider Plant",
+    botanicalName: "Chlorophytum comosum",
+    imageUrl:
+      "https://images.unsplash.com/photo-1607363380021-9f1cce0cde24?q=80&w=2970&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Low",
+    lightNeed: "Partial Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "The Spider Plant is a resilient houseplant known for its air-purifying qualities and ability to thrive in a variety of light conditions.",
+  },
+  {
+    id: "5",
+    name: "Peace Lily",
+    botanicalName: "Spathiphyllum",
+    imageUrl:
+      "https://images.unsplash.com/photo-1629811119888-dde7186c1fb5?q=80&w=2874&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "High",
+    lightNeed: "Full Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "Peace Lilies are known for their beautiful white flowers and ability to thrive in low light. They require frequent watering to maintain their lush foliage.",
+  },
+  {
+    id: "6",
+    name: "Rubber Plant",
+    botanicalName: "Ficus elastica",
+    imageUrl:
+      "https://images.unsplash.com/photo-1643227565928-0cc454ec4937?q=80&w=2874&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Medium",
+    lightNeed: "Partial Shade",
+    fertiliserSeason: ["Spring", "Fall"],
+    description:
+      "The Rubber Plant is a popular indoor tree with large, glossy leaves. It thrives in medium to bright light and needs regular watering.",
+  },
+  {
+    id: "7",
+    name: "ZZ Plant",
+    botanicalName: "Zamioculcas zamiifolia",
+    imageUrl:
+      "https://images.unsplash.com/photo-1536882240095-0379873feb4e?q=80&w=2971&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Low",
+    lightNeed: "Partial Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "The ZZ Plant is a hardy and drought-tolerant plant that can survive in low light and requires minimal watering, making it perfect for beginners.",
+  },
+  {
+    id: "8",
+    name: "Monstera Deliciosa",
+    botanicalName: "Monstera deliciosa",
+    imageUrl:
+      "https://images.unsplash.com/photo-1545165375-1b744b9ed444?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Medium",
+    lightNeed: "Partial Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "Monstera Deliciosa, also known as the Swiss Cheese Plant, is famous for its large, split leaves. It prefers indirect light and moderate watering.",
+  },
+  {
+    id: "9",
+    name: "Pothos",
+    botanicalName: "Epipremnum aureum",
+    imageUrl:
+      "https://images.unsplash.com/photo-1598880940080-ff9a29891b85?q=80&w=1528&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Low",
+    lightNeed: "Partial Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "Pothos is a versatile and low-maintenance plant that can thrive in low light and requires infrequent watering. It's known for its trailing vines.",
+  },
+  {
+    id: "10",
+    name: "Boston Fern",
+    botanicalName: "Nephrolepis exaltata",
+    imageUrl:
+      "https://images.unsplash.com/photo-1619398221730-09294c6d4139?q=80&w=1587&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "High",
+    lightNeed: "Partial Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "Boston Ferns are lush, green plants that thrive in humid environments with bright, indirect light. They need regular watering to keep their fronds healthy.",
+  },
+  {
+    id: "11",
+    name: "Orchid",
+    botanicalName: "Orchidaceae",
+    imageUrl:
+      "https://images.unsplash.com/photo-1454262041357-5d96f50a2f27?q=80&w=1469&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Low",
+    lightNeed: "Partial Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "Orchids are elegant flowering plants that prefer bright, indirect light and minimal watering. They are known for their beautiful and long-lasting blooms.",
+  },
+  {
+    id: "12",
+    name: "Jade Plant",
+    botanicalName: "Crassula ovata",
+    imageUrl:
+      "https://images.unsplash.com/photo-1620127620051-fea30e50c66e?q=80&w=1528&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Low",
+    lightNeed: "Full Sun",
+    fertiliserSeason: ["Spring", "Fall"],
+    description:
+      "The Jade Plant is a succulent known for its thick, fleshy leaves. It thrives in bright light and requires minimal watering, making it easy to care for.",
+  },
+  {
+    id: "13",
+    name: "Philodendron",
+    botanicalName: "Philodendron spp.",
+    imageUrl:
+      "https://images.unsplash.com/photo-1675678964961-4c04733ee34a?q=80&w=1528&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Medium",
+    lightNeed: "Partial Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "Philodendrons are popular houseplants known for their heart-shaped leaves. They prefer indirect light and consistent watering.",
+  },
+  {
+    id: "14",
+    name: "Cactus",
+    botanicalName: "Cactaceae",
+    imageUrl:
+      "https://images.unsplash.com/photo-1497214068716-571605b05ca8?q=80&w=1471&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Low",
+    lightNeed: "Full Sun",
+    fertiliserSeason: ["Summer"],
+    description:
+      "Cacti are desert plants that thrive in bright light and require very little water. They are known for their unique shapes and spines.",
+  },
+  {
+    id: "15",
+    name: "Lavender",
+    botanicalName: "Lavandula",
+    imageUrl:
+      "https://images.unsplash.com/photo-1592685776885-97a964ad8293?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Low",
+    lightNeed: "Full Sun",
+    fertiliserSeason: ["Spring"],
+    description:
+      "Lavender is a fragrant herb known for its purple flowers and soothing scent. It requires full sun and minimal watering.",
+  },
+  {
+    id: "16",
+    name: "Succulent",
+    botanicalName: "Succulents",
+    imageUrl:
+      "https://images.unsplash.com/photo-1509069575671-3df40ce5307c?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Low",
+    lightNeed: "Full Sun",
+    fertiliserSeason: ["Summer", "Fall"],
+    description:
+      "Succulents are a diverse group of plants known for their water-storing capabilities. They thrive in bright light and require minimal watering.",
+  },
+  {
+    id: "17",
+    name: "Calathea",
+    botanicalName: "Calathea spp.",
+    imageUrl:
+      "https://images.unsplash.com/photo-1602879946327-8b4a148c367d?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "High",
+    lightNeed: "Full Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "Calatheas are known for their stunning, patterned leaves. They thrive in low light and high humidity, requiring regular watering to keep their foliage vibrant.",
+  },
+  {
+    id: "18",
+    name: "Yucca",
+    botanicalName: "Yucca",
+    imageUrl:
+      "https://images.unsplash.com/photo-1629516676153-26a76b83701f?q=80&w=1480&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Low",
+    lightNeed: "Full Sun",
+    fertiliserSeason: ["Spring"],
+    description:
+      "Yucca plants are hardy and drought-tolerant, known for their long, sword-shaped leaves. They thrive in bright light and require minimal watering.",
+  },
+  {
+    id: "19",
+    name: "Bamboo",
+    botanicalName: "Bambusoideae",
+    imageUrl:
+      "https://images.unsplash.com/photo-1426020744253-568cd6345e93?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Medium",
+    lightNeed: "Full Sun",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "Bamboo plants are fast-growing and known for their tall, graceful stalks. They prefer bright light and consistent watering, especially during the growing season.",
+  },
+  {
+    id: "20",
+    name: "Anthurium",
+    botanicalName: "Anthurium",
+    imageUrl:
+      "https://images.unsplash.com/photo-1632906379687-355e24798632?q=80&w=1973&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Medium",
+    lightNeed: "Partial Shade",
+    fertiliserSeason: ["Spring", "Fall"],
+    description:
+      "Anthuriums are known for their striking, heart-shaped flowers and glossy leaves. They prefer bright, indirect light and moderate watering.",
+  },
+  {
+    id: "21",
+    name: "English Ivy",
+    botanicalName: "Hedera helix",
+    imageUrl:
+      "https://images.unsplash.com/photo-1724723942347-b113f0cd4a67?q=80&w=2072&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Medium",
+    lightNeed: "Full Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "English Ivy is a versatile plant known for its trailing vines and ability to thrive in shaded areas. It requires moderate watering.",
+  },
+  {
+    id: "22",
+    name: "Dumb Cane",
+    botanicalName: "Dieffenbachia",
+    imageUrl:
+      "https://images.unsplash.com/photo-1631556941887-f81ab0ecfda9?q=80&w=1960&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "High",
+    lightNeed: "Partial Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "Dumb Cane is a popular houseplant known for its large, variegated leaves. It prefers indirect light and regular watering.",
+  },
+  {
+    id: "23",
+    name: "Golden Pothos",
+    botanicalName: "Epipremnum aureum",
+    imageUrl:
+      "https://images.unsplash.com/photo-1674482918961-57a3a0484bf3?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Low",
+    lightNeed: "Partial Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "Golden Pothos is a low-maintenance plant that can thrive in low light and requires infrequent watering. It's known for its trailing vines.",
+  },
+  {
+    id: "24",
+    name: "Peace Lily",
+    botanicalName: "Spathiphyllum",
+    imageUrl:
+      "https://images.unsplash.com/photo-1616694547693-b0f829a6cf30?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8UGVhY2UlMjBMaWx5fGVufDB8MHwwfHx8Mg%3D%3D",
+    waterNeed: "High",
+    lightNeed: "Full Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "Peace Lilies are known for their beautiful white flowers and ability to thrive in low light. They require frequent watering to maintain their lush foliage.",
+  },
+  {
+    id: "25",
+    name: "Areca Palm",
+    botanicalName: "Dypsis lutescens",
+    imageUrl:
+      "https://images.pexels.com/photos/5538833/pexels-photo-5538833.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1",
+    waterNeed: "Medium",
+    lightNeed: "Partial Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "Areca Palms are popular indoor palms known for their feathery, arching fronds. They prefer indirect light and regular watering.",
+  },
+  {
+    id: "26",
+    name: "Swiss Cheese Plant",
+    botanicalName: "Monstera adansonii",
+    imageUrl:
+      "https://images.unsplash.com/photo-1604066538249-f3767aa55545?q=80&w=2074&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Medium",
+    lightNeed: "Partial Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "The Swiss Cheese Plant is known for its unique, perforated leaves. It prefers bright, indirect light and moderate watering.",
+  },
+  {
+    id: "27",
+    name: "Chinese Money Plant",
+    botanicalName: "Pilea peperomioides",
+    imageUrl:
+      "https://images.unsplash.com/photo-1723650879990-dae890387cff?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Low",
+    lightNeed: "Partial Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "The Chinese Money Plant is a trendy houseplant known for its round, coin-shaped leaves. It thrives in bright, indirect light and requires minimal watering.",
+  },
+  {
+    id: "28",
+    name: "Bird of Paradise",
+    botanicalName: "Strelitzia reginae",
+    imageUrl:
+      "https://images.unsplash.com/photo-1591484599836-a9548b9ebbc8?q=80&w=2031&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "High",
+    lightNeed: "Full Sun",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "Bird of Paradise is known for its striking, tropical flowers. It requires bright light and regular watering to thrive.",
+  },
+  {
+    id: "29",
+    name: "Jade Plant",
+    botanicalName: "Crassula ovata",
+    imageUrl:
+      "https://images.pexels.com/photos/8507297/pexels-photo-8507297.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1",
+    waterNeed: "Low",
+    lightNeed: "Full Sun",
+    fertiliserSeason: ["Spring", "Fall"],
+    description:
+      "The Jade Plant is a succulent known for its thick, fleshy leaves. It thrives in bright light and requires minimal watering, making it easy to care for.",
+  },
+  {
+    id: "30",
+    name: "African Violet",
+    botanicalName: "Saintpaulia",
+    imageUrl:
+      "https://images.pexels.com/photos/5706695/pexels-photo-5706695.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1",
+    waterNeed: "Medium",
+    lightNeed: "Partial Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "African Violets are popular indoor flowering plants known for their vibrant, velvety flowers. They prefer indirect light and moderate watering.",
+  },
 ];

--- a/lib/data.js
+++ b/lib/data.js
@@ -11,352 +11,352 @@ export const plants = [
     description:
       "The Snake Plant, also known as Mother-in-Law's Tongue, is a hardy and low-maintenance plant that can thrive in low light and requires minimal watering.",
   },
-  {
-    id: "2",
-    name: "Fiddle Leaf Fig",
-    botanicalName: "Ficus lyrata",
-    imageUrl:
-      "https://images.unsplash.com/photo-1498766707495-856f300a5821?q=80&w=2971&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Medium",
-    lightNeed: "Full Sun",
-    fertiliserSeason: ["Spring"],
-    description:
-      "The Fiddle Leaf Fig is a popular indoor tree known for its large, violin-shaped leaves. It prefers bright, indirect light and consistent watering.",
-  },
-  {
-    id: "3",
-    name: "Aloe Vera",
-    botanicalName: "Aloe barbadensis miller",
-    imageUrl:
-      "https://images.unsplash.com/photo-1702416062979-dc44baa952c1?q=80&w=2970&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Low",
-    lightNeed: "Full Sun",
-    fertiliserSeason: ["Summer"],
-    description:
-      "Aloe Vera is a succulent plant species known for its medicinal properties. It requires bright light and minimal water, making it easy to care for.",
-  },
-  {
-    id: "4",
-    name: "Spider Plant",
-    botanicalName: "Chlorophytum comosum",
-    imageUrl:
-      "https://images.unsplash.com/photo-1607363380021-9f1cce0cde24?q=80&w=2970&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Low",
-    lightNeed: "Partial Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "The Spider Plant is a resilient houseplant known for its air-purifying qualities and ability to thrive in a variety of light conditions.",
-  },
-  {
-    id: "5",
-    name: "Peace Lily",
-    botanicalName: "Spathiphyllum",
-    imageUrl:
-      "https://images.unsplash.com/photo-1629811119888-dde7186c1fb5?q=80&w=2874&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "High",
-    lightNeed: "Full Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "Peace Lilies are known for their beautiful white flowers and ability to thrive in low light. They require frequent watering to maintain their lush foliage.",
-  },
-  {
-    id: "6",
-    name: "Rubber Plant",
-    botanicalName: "Ficus elastica",
-    imageUrl:
-      "https://images.unsplash.com/photo-1643227565928-0cc454ec4937?q=80&w=2874&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Medium",
-    lightNeed: "Partial Shade",
-    fertiliserSeason: ["Spring", "Fall"],
-    description:
-      "The Rubber Plant is a popular indoor tree with large, glossy leaves. It thrives in medium to bright light and needs regular watering.",
-  },
-  {
-    id: "7",
-    name: "ZZ Plant",
-    botanicalName: "Zamioculcas zamiifolia",
-    imageUrl:
-      "https://images.unsplash.com/photo-1536882240095-0379873feb4e?q=80&w=2971&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Low",
-    lightNeed: "Partial Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "The ZZ Plant is a hardy and drought-tolerant plant that can survive in low light and requires minimal watering, making it perfect for beginners.",
-  },
-  {
-    id: "8",
-    name: "Monstera Deliciosa",
-    botanicalName: "Monstera deliciosa",
-    imageUrl:
-      "https://images.unsplash.com/photo-1545165375-1b744b9ed444?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Medium",
-    lightNeed: "Partial Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "Monstera Deliciosa, also known as the Swiss Cheese Plant, is famous for its large, split leaves. It prefers indirect light and moderate watering.",
-  },
-  {
-    id: "9",
-    name: "Pothos",
-    botanicalName: "Epipremnum aureum",
-    imageUrl:
-      "https://images.unsplash.com/photo-1598880940080-ff9a29891b85?q=80&w=1528&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Low",
-    lightNeed: "Partial Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "Pothos is a versatile and low-maintenance plant that can thrive in low light and requires infrequent watering. It's known for its trailing vines.",
-  },
-  {
-    id: "10",
-    name: "Boston Fern",
-    botanicalName: "Nephrolepis exaltata",
-    imageUrl:
-      "https://images.unsplash.com/photo-1619398221730-09294c6d4139?q=80&w=1587&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "High",
-    lightNeed: "Partial Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "Boston Ferns are lush, green plants that thrive in humid environments with bright, indirect light. They need regular watering to keep their fronds healthy.",
-  },
-  {
-    id: "11",
-    name: "Orchid",
-    botanicalName: "Orchidaceae",
-    imageUrl:
-      "https://images.unsplash.com/photo-1454262041357-5d96f50a2f27?q=80&w=1469&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Low",
-    lightNeed: "Partial Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "Orchids are elegant flowering plants that prefer bright, indirect light and minimal watering. They are known for their beautiful and long-lasting blooms.",
-  },
-  {
-    id: "12",
-    name: "Jade Plant",
-    botanicalName: "Crassula ovata",
-    imageUrl:
-      "https://images.unsplash.com/photo-1620127620051-fea30e50c66e?q=80&w=1528&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Low",
-    lightNeed: "Full Sun",
-    fertiliserSeason: ["Spring", "Fall"],
-    description:
-      "The Jade Plant is a succulent known for its thick, fleshy leaves. It thrives in bright light and requires minimal watering, making it easy to care for.",
-  },
-  {
-    id: "13",
-    name: "Philodendron",
-    botanicalName: "Philodendron spp.",
-    imageUrl:
-      "https://images.unsplash.com/photo-1675678964961-4c04733ee34a?q=80&w=1528&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Medium",
-    lightNeed: "Partial Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "Philodendrons are popular houseplants known for their heart-shaped leaves. They prefer indirect light and consistent watering.",
-  },
-  {
-    id: "14",
-    name: "Cactus",
-    botanicalName: "Cactaceae",
-    imageUrl:
-      "https://images.unsplash.com/photo-1497214068716-571605b05ca8?q=80&w=1471&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Low",
-    lightNeed: "Full Sun",
-    fertiliserSeason: ["Summer"],
-    description:
-      "Cacti are desert plants that thrive in bright light and require very little water. They are known for their unique shapes and spines.",
-  },
-  {
-    id: "15",
-    name: "Lavender",
-    botanicalName: "Lavandula",
-    imageUrl:
-      "https://images.unsplash.com/photo-1592685776885-97a964ad8293?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Low",
-    lightNeed: "Full Sun",
-    fertiliserSeason: ["Spring"],
-    description:
-      "Lavender is a fragrant herb known for its purple flowers and soothing scent. It requires full sun and minimal watering.",
-  },
-  {
-    id: "16",
-    name: "Succulent",
-    botanicalName: "Succulents",
-    imageUrl:
-      "https://images.unsplash.com/photo-1509069575671-3df40ce5307c?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Low",
-    lightNeed: "Full Sun",
-    fertiliserSeason: ["Summer", "Fall"],
-    description:
-      "Succulents are a diverse group of plants known for their water-storing capabilities. They thrive in bright light and require minimal watering.",
-  },
-  {
-    id: "17",
-    name: "Calathea",
-    botanicalName: "Calathea spp.",
-    imageUrl:
-      "https://images.unsplash.com/photo-1602879946327-8b4a148c367d?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "High",
-    lightNeed: "Full Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "Calatheas are known for their stunning, patterned leaves. They thrive in low light and high humidity, requiring regular watering to keep their foliage vibrant.",
-  },
-  {
-    id: "18",
-    name: "Yucca",
-    botanicalName: "Yucca",
-    imageUrl:
-      "https://images.unsplash.com/photo-1629516676153-26a76b83701f?q=80&w=1480&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Low",
-    lightNeed: "Full Sun",
-    fertiliserSeason: ["Spring"],
-    description:
-      "Yucca plants are hardy and drought-tolerant, known for their long, sword-shaped leaves. They thrive in bright light and require minimal watering.",
-  },
-  {
-    id: "19",
-    name: "Bamboo",
-    botanicalName: "Bambusoideae",
-    imageUrl:
-      "https://images.unsplash.com/photo-1426020744253-568cd6345e93?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Medium",
-    lightNeed: "Full Sun",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "Bamboo plants are fast-growing and known for their tall, graceful stalks. They prefer bright light and consistent watering, especially during the growing season.",
-  },
-  {
-    id: "20",
-    name: "Anthurium",
-    botanicalName: "Anthurium",
-    imageUrl:
-      "https://images.unsplash.com/photo-1632906379687-355e24798632?q=80&w=1973&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Medium",
-    lightNeed: "Partial Shade",
-    fertiliserSeason: ["Spring", "Fall"],
-    description:
-      "Anthuriums are known for their striking, heart-shaped flowers and glossy leaves. They prefer bright, indirect light and moderate watering.",
-  },
-  {
-    id: "21",
-    name: "English Ivy",
-    botanicalName: "Hedera helix",
-    imageUrl:
-      "https://images.unsplash.com/photo-1724723942347-b113f0cd4a67?q=80&w=2072&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Medium",
-    lightNeed: "Full Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "English Ivy is a versatile plant known for its trailing vines and ability to thrive in shaded areas. It requires moderate watering.",
-  },
-  {
-    id: "22",
-    name: "Dumb Cane",
-    botanicalName: "Dieffenbachia",
-    imageUrl:
-      "https://images.unsplash.com/photo-1631556941887-f81ab0ecfda9?q=80&w=1960&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "High",
-    lightNeed: "Partial Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "Dumb Cane is a popular houseplant known for its large, variegated leaves. It prefers indirect light and regular watering.",
-  },
-  {
-    id: "23",
-    name: "Golden Pothos",
-    botanicalName: "Epipremnum aureum",
-    imageUrl:
-      "https://images.unsplash.com/photo-1674482918961-57a3a0484bf3?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Low",
-    lightNeed: "Partial Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "Golden Pothos is a low-maintenance plant that can thrive in low light and requires infrequent watering. It's known for its trailing vines.",
-  },
-  {
-    id: "24",
-    name: "Peace Lily",
-    botanicalName: "Spathiphyllum",
-    imageUrl:
-      "https://images.unsplash.com/photo-1616694547693-b0f829a6cf30?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8UGVhY2UlMjBMaWx5fGVufDB8MHwwfHx8Mg%3D%3D",
-    waterNeed: "High",
-    lightNeed: "Full Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "Peace Lilies are known for their beautiful white flowers and ability to thrive in low light. They require frequent watering to maintain their lush foliage.",
-  },
-  {
-    id: "25",
-    name: "Areca Palm",
-    botanicalName: "Dypsis lutescens",
-    imageUrl:
-      "https://images.pexels.com/photos/5538833/pexels-photo-5538833.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1",
-    waterNeed: "Medium",
-    lightNeed: "Partial Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "Areca Palms are popular indoor palms known for their feathery, arching fronds. They prefer indirect light and regular watering.",
-  },
-  {
-    id: "26",
-    name: "Swiss Cheese Plant",
-    botanicalName: "Monstera adansonii",
-    imageUrl:
-      "https://images.unsplash.com/photo-1604066538249-f3767aa55545?q=80&w=2074&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Medium",
-    lightNeed: "Partial Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "The Swiss Cheese Plant is known for its unique, perforated leaves. It prefers bright, indirect light and moderate watering.",
-  },
-  {
-    id: "27",
-    name: "Chinese Money Plant",
-    botanicalName: "Pilea peperomioides",
-    imageUrl:
-      "https://images.unsplash.com/photo-1723650879990-dae890387cff?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Low",
-    lightNeed: "Partial Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "The Chinese Money Plant is a trendy houseplant known for its round, coin-shaped leaves. It thrives in bright, indirect light and requires minimal watering.",
-  },
-  {
-    id: "28",
-    name: "Bird of Paradise",
-    botanicalName: "Strelitzia reginae",
-    imageUrl:
-      "https://images.unsplash.com/photo-1591484599836-a9548b9ebbc8?q=80&w=2031&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "High",
-    lightNeed: "Full Sun",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "Bird of Paradise is known for its striking, tropical flowers. It requires bright light and regular watering to thrive.",
-  },
-  {
-    id: "29",
-    name: "Jade Plant",
-    botanicalName: "Crassula ovata",
-    imageUrl:
-      "https://images.pexels.com/photos/8507297/pexels-photo-8507297.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1",
-    waterNeed: "Low",
-    lightNeed: "Full Sun",
-    fertiliserSeason: ["Spring", "Fall"],
-    description:
-      "The Jade Plant is a succulent known for its thick, fleshy leaves. It thrives in bright light and requires minimal watering, making it easy to care for.",
-  },
-  {
-    id: "30",
-    name: "African Violet",
-    botanicalName: "Saintpaulia",
-    imageUrl:
-      "https://images.pexels.com/photos/5706695/pexels-photo-5706695.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1",
-    waterNeed: "Medium",
-    lightNeed: "Partial Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "African Violets are popular indoor flowering plants known for their vibrant, velvety flowers. They prefer indirect light and moderate watering.",
-  },
+  // {
+  //   id: "2",
+  //   name: "Fiddle Leaf Fig",
+  //   botanicalName: "Ficus lyrata",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1498766707495-856f300a5821?q=80&w=2971&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Medium",
+  //   lightNeed: "Full Sun",
+  //   fertiliserSeason: ["Spring"],
+  //   description:
+  //     "The Fiddle Leaf Fig is a popular indoor tree known for its large, violin-shaped leaves. It prefers bright, indirect light and consistent watering.",
+  // },
+  // {
+  //   id: "3",
+  //   name: "Aloe Vera",
+  //   botanicalName: "Aloe barbadensis miller",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1702416062979-dc44baa952c1?q=80&w=2970&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Low",
+  //   lightNeed: "Full Sun",
+  //   fertiliserSeason: ["Summer"],
+  //   description:
+  //     "Aloe Vera is a succulent plant species known for its medicinal properties. It requires bright light and minimal water, making it easy to care for.",
+  // },
+  // {
+  //   id: "4",
+  //   name: "Spider Plant",
+  //   botanicalName: "Chlorophytum comosum",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1607363380021-9f1cce0cde24?q=80&w=2970&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Low",
+  //   lightNeed: "Partial Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "The Spider Plant is a resilient houseplant known for its air-purifying qualities and ability to thrive in a variety of light conditions.",
+  // },
+  // {
+  //   id: "5",
+  //   name: "Peace Lily",
+  //   botanicalName: "Spathiphyllum",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1629811119888-dde7186c1fb5?q=80&w=2874&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "High",
+  //   lightNeed: "Full Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "Peace Lilies are known for their beautiful white flowers and ability to thrive in low light. They require frequent watering to maintain their lush foliage.",
+  // },
+  // {
+  //   id: "6",
+  //   name: "Rubber Plant",
+  //   botanicalName: "Ficus elastica",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1643227565928-0cc454ec4937?q=80&w=2874&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Medium",
+  //   lightNeed: "Partial Shade",
+  //   fertiliserSeason: ["Spring", "Fall"],
+  //   description:
+  //     "The Rubber Plant is a popular indoor tree with large, glossy leaves. It thrives in medium to bright light and needs regular watering.",
+  // },
+  // {
+  //   id: "7",
+  //   name: "ZZ Plant",
+  //   botanicalName: "Zamioculcas zamiifolia",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1536882240095-0379873feb4e?q=80&w=2971&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Low",
+  //   lightNeed: "Partial Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "The ZZ Plant is a hardy and drought-tolerant plant that can survive in low light and requires minimal watering, making it perfect for beginners.",
+  // },
+  // {
+  //   id: "8",
+  //   name: "Monstera Deliciosa",
+  //   botanicalName: "Monstera deliciosa",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1545165375-1b744b9ed444?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Medium",
+  //   lightNeed: "Partial Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "Monstera Deliciosa, also known as the Swiss Cheese Plant, is famous for its large, split leaves. It prefers indirect light and moderate watering.",
+  // },
+  // {
+  //   id: "9",
+  //   name: "Pothos",
+  //   botanicalName: "Epipremnum aureum",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1598880940080-ff9a29891b85?q=80&w=1528&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Low",
+  //   lightNeed: "Partial Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "Pothos is a versatile and low-maintenance plant that can thrive in low light and requires infrequent watering. It's known for its trailing vines.",
+  // },
+  // {
+  //   id: "10",
+  //   name: "Boston Fern",
+  //   botanicalName: "Nephrolepis exaltata",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1619398221730-09294c6d4139?q=80&w=1587&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "High",
+  //   lightNeed: "Partial Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "Boston Ferns are lush, green plants that thrive in humid environments with bright, indirect light. They need regular watering to keep their fronds healthy.",
+  // },
+  // {
+  //   id: "11",
+  //   name: "Orchid",
+  //   botanicalName: "Orchidaceae",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1454262041357-5d96f50a2f27?q=80&w=1469&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Low",
+  //   lightNeed: "Partial Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "Orchids are elegant flowering plants that prefer bright, indirect light and minimal watering. They are known for their beautiful and long-lasting blooms.",
+  // },
+  // {
+  //   id: "12",
+  //   name: "Jade Plant",
+  //   botanicalName: "Crassula ovata",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1620127620051-fea30e50c66e?q=80&w=1528&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Low",
+  //   lightNeed: "Full Sun",
+  //   fertiliserSeason: ["Spring", "Fall"],
+  //   description:
+  //     "The Jade Plant is a succulent known for its thick, fleshy leaves. It thrives in bright light and requires minimal watering, making it easy to care for.",
+  // },
+  // {
+  //   id: "13",
+  //   name: "Philodendron",
+  //   botanicalName: "Philodendron spp.",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1675678964961-4c04733ee34a?q=80&w=1528&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Medium",
+  //   lightNeed: "Partial Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "Philodendrons are popular houseplants known for their heart-shaped leaves. They prefer indirect light and consistent watering.",
+  // },
+  // {
+  //   id: "14",
+  //   name: "Cactus",
+  //   botanicalName: "Cactaceae",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1497214068716-571605b05ca8?q=80&w=1471&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Low",
+  //   lightNeed: "Full Sun",
+  //   fertiliserSeason: ["Summer"],
+  //   description:
+  //     "Cacti are desert plants that thrive in bright light and require very little water. They are known for their unique shapes and spines.",
+  // },
+  // {
+  //   id: "15",
+  //   name: "Lavender",
+  //   botanicalName: "Lavandula",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1592685776885-97a964ad8293?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Low",
+  //   lightNeed: "Full Sun",
+  //   fertiliserSeason: ["Spring"],
+  //   description:
+  //     "Lavender is a fragrant herb known for its purple flowers and soothing scent. It requires full sun and minimal watering.",
+  // },
+  // {
+  //   id: "16",
+  //   name: "Succulent",
+  //   botanicalName: "Succulents",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1509069575671-3df40ce5307c?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Low",
+  //   lightNeed: "Full Sun",
+  //   fertiliserSeason: ["Summer", "Fall"],
+  //   description:
+  //     "Succulents are a diverse group of plants known for their water-storing capabilities. They thrive in bright light and require minimal watering.",
+  // },
+  // {
+  //   id: "17",
+  //   name: "Calathea",
+  //   botanicalName: "Calathea spp.",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1602879946327-8b4a148c367d?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "High",
+  //   lightNeed: "Full Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "Calatheas are known for their stunning, patterned leaves. They thrive in low light and high humidity, requiring regular watering to keep their foliage vibrant.",
+  // },
+  // {
+  //   id: "18",
+  //   name: "Yucca",
+  //   botanicalName: "Yucca",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1629516676153-26a76b83701f?q=80&w=1480&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Low",
+  //   lightNeed: "Full Sun",
+  //   fertiliserSeason: ["Spring"],
+  //   description:
+  //     "Yucca plants are hardy and drought-tolerant, known for their long, sword-shaped leaves. They thrive in bright light and require minimal watering.",
+  // },
+  // {
+  //   id: "19",
+  //   name: "Bamboo",
+  //   botanicalName: "Bambusoideae",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1426020744253-568cd6345e93?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Medium",
+  //   lightNeed: "Full Sun",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "Bamboo plants are fast-growing and known for their tall, graceful stalks. They prefer bright light and consistent watering, especially during the growing season.",
+  // },
+  // {
+  //   id: "20",
+  //   name: "Anthurium",
+  //   botanicalName: "Anthurium",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1632906379687-355e24798632?q=80&w=1973&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Medium",
+  //   lightNeed: "Partial Shade",
+  //   fertiliserSeason: ["Spring", "Fall"],
+  //   description:
+  //     "Anthuriums are known for their striking, heart-shaped flowers and glossy leaves. They prefer bright, indirect light and moderate watering.",
+  // },
+  // {
+  //   id: "21",
+  //   name: "English Ivy",
+  //   botanicalName: "Hedera helix",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1724723942347-b113f0cd4a67?q=80&w=2072&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Medium",
+  //   lightNeed: "Full Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "English Ivy is a versatile plant known for its trailing vines and ability to thrive in shaded areas. It requires moderate watering.",
+  // },
+  // {
+  //   id: "22",
+  //   name: "Dumb Cane",
+  //   botanicalName: "Dieffenbachia",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1631556941887-f81ab0ecfda9?q=80&w=1960&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "High",
+  //   lightNeed: "Partial Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "Dumb Cane is a popular houseplant known for its large, variegated leaves. It prefers indirect light and regular watering.",
+  // },
+  // {
+  //   id: "23",
+  //   name: "Golden Pothos",
+  //   botanicalName: "Epipremnum aureum",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1674482918961-57a3a0484bf3?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Low",
+  //   lightNeed: "Partial Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "Golden Pothos is a low-maintenance plant that can thrive in low light and requires infrequent watering. It's known for its trailing vines.",
+  // },
+  // {
+  //   id: "24",
+  //   name: "Peace Lily",
+  //   botanicalName: "Spathiphyllum",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1616694547693-b0f829a6cf30?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8UGVhY2UlMjBMaWx5fGVufDB8MHwwfHx8Mg%3D%3D",
+  //   waterNeed: "High",
+  //   lightNeed: "Full Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "Peace Lilies are known for their beautiful white flowers and ability to thrive in low light. They require frequent watering to maintain their lush foliage.",
+  // },
+  // {
+  //   id: "25",
+  //   name: "Areca Palm",
+  //   botanicalName: "Dypsis lutescens",
+  //   imageUrl:
+  //     "https://images.pexels.com/photos/5538833/pexels-photo-5538833.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1",
+  //   waterNeed: "Medium",
+  //   lightNeed: "Partial Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "Areca Palms are popular indoor palms known for their feathery, arching fronds. They prefer indirect light and regular watering.",
+  // },
+  // {
+  //   id: "26",
+  //   name: "Swiss Cheese Plant",
+  //   botanicalName: "Monstera adansonii",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1604066538249-f3767aa55545?q=80&w=2074&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Medium",
+  //   lightNeed: "Partial Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "The Swiss Cheese Plant is known for its unique, perforated leaves. It prefers bright, indirect light and moderate watering.",
+  // },
+  // {
+  //   id: "27",
+  //   name: "Chinese Money Plant",
+  //   botanicalName: "Pilea peperomioides",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1723650879990-dae890387cff?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Low",
+  //   lightNeed: "Partial Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "The Chinese Money Plant is a trendy houseplant known for its round, coin-shaped leaves. It thrives in bright, indirect light and requires minimal watering.",
+  // },
+  // {
+  //   id: "28",
+  //   name: "Bird of Paradise",
+  //   botanicalName: "Strelitzia reginae",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1591484599836-a9548b9ebbc8?q=80&w=2031&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "High",
+  //   lightNeed: "Full Sun",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "Bird of Paradise is known for its striking, tropical flowers. It requires bright light and regular watering to thrive.",
+  // },
+  // {
+  //   id: "29",
+  //   name: "Jade Plant",
+  //   botanicalName: "Crassula ovata",
+  //   imageUrl:
+  //     "https://images.pexels.com/photos/8507297/pexels-photo-8507297.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1",
+  //   waterNeed: "Low",
+  //   lightNeed: "Full Sun",
+  //   fertiliserSeason: ["Spring", "Fall"],
+  //   description:
+  //     "The Jade Plant is a succulent known for its thick, fleshy leaves. It thrives in bright light and requires minimal watering, making it easy to care for.",
+  // },
+  // {
+  //   id: "30",
+  //   name: "African Violet",
+  //   botanicalName: "Saintpaulia",
+  //   imageUrl:
+  //     "https://images.pexels.com/photos/5706695/pexels-photo-5706695.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1",
+  //   waterNeed: "Medium",
+  //   lightNeed: "Partial Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "African Violets are popular indoor flowering plants known for their vibrant, velvety flowers. They prefer indirect light and moderate watering.",
+  // },
 ];

--- a/lib/data.js
+++ b/lib/data.js
@@ -1,352 +1,352 @@
 export const plants = [
-  {
-    id: "1",
-    name: "Snake Plant",
-    botanicalName: "Sansevieria trifasciata",
-    imageUrl:
-      "https://images.unsplash.com/photo-1651760548494-4b906ed1600c?q=80&w=2970&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Low",
-    lightNeed: "Partial Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "The Snake Plant, also known as Mother-in-Law's Tongue, is a hardy and low-maintenance plant that can thrive in low light and requires minimal watering.",
-  },
-  {
-    id: "2",
-    name: "Fiddle Leaf Fig",
-    botanicalName: "Ficus lyrata",
-    imageUrl:
-      "https://images.unsplash.com/photo-1498766707495-856f300a5821?q=80&w=2971&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Medium",
-    lightNeed: "Full Sun",
-    fertiliserSeason: ["Spring"],
-    description:
-      "The Fiddle Leaf Fig is a popular indoor tree known for its large, violin-shaped leaves. It prefers bright, indirect light and consistent watering.",
-  },
-  {
-    id: "3",
-    name: "Aloe Vera",
-    botanicalName: "Aloe barbadensis miller",
-    imageUrl:
-      "https://images.unsplash.com/photo-1702416062979-dc44baa952c1?q=80&w=2970&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Low",
-    lightNeed: "Full Sun",
-    fertiliserSeason: ["Summer"],
-    description:
-      "Aloe Vera is a succulent plant species known for its medicinal properties. It requires bright light and minimal water, making it easy to care for.",
-  },
-  {
-    id: "4",
-    name: "Spider Plant",
-    botanicalName: "Chlorophytum comosum",
-    imageUrl:
-      "https://images.unsplash.com/photo-1607363380021-9f1cce0cde24?q=80&w=2970&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Low",
-    lightNeed: "Partial Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "The Spider Plant is a resilient houseplant known for its air-purifying qualities and ability to thrive in a variety of light conditions.",
-  },
-  {
-    id: "5",
-    name: "Peace Lily",
-    botanicalName: "Spathiphyllum",
-    imageUrl:
-      "https://images.unsplash.com/photo-1629811119888-dde7186c1fb5?q=80&w=2874&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "High",
-    lightNeed: "Full Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "Peace Lilies are known for their beautiful white flowers and ability to thrive in low light. They require frequent watering to maintain their lush foliage.",
-  },
-  {
-    id: "6",
-    name: "Rubber Plant",
-    botanicalName: "Ficus elastica",
-    imageUrl:
-      "https://images.unsplash.com/photo-1643227565928-0cc454ec4937?q=80&w=2874&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Medium",
-    lightNeed: "Partial Shade",
-    fertiliserSeason: ["Spring", "Fall"],
-    description:
-      "The Rubber Plant is a popular indoor tree with large, glossy leaves. It thrives in medium to bright light and needs regular watering.",
-  },
-  {
-    id: "7",
-    name: "ZZ Plant",
-    botanicalName: "Zamioculcas zamiifolia",
-    imageUrl:
-      "https://images.unsplash.com/photo-1536882240095-0379873feb4e?q=80&w=2971&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Low",
-    lightNeed: "Partial Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "The ZZ Plant is a hardy and drought-tolerant plant that can survive in low light and requires minimal watering, making it perfect for beginners.",
-  },
-  {
-    id: "8",
-    name: "Monstera Deliciosa",
-    botanicalName: "Monstera deliciosa",
-    imageUrl:
-      "https://images.unsplash.com/photo-1545165375-1b744b9ed444?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Medium",
-    lightNeed: "Partial Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "Monstera Deliciosa, also known as the Swiss Cheese Plant, is famous for its large, split leaves. It prefers indirect light and moderate watering.",
-  },
-  {
-    id: "9",
-    name: "Pothos",
-    botanicalName: "Epipremnum aureum",
-    imageUrl:
-      "https://images.unsplash.com/photo-1598880940080-ff9a29891b85?q=80&w=1528&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Low",
-    lightNeed: "Partial Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "Pothos is a versatile and low-maintenance plant that can thrive in low light and requires infrequent watering. It's known for its trailing vines.",
-  },
-  {
-    id: "10",
-    name: "Boston Fern",
-    botanicalName: "Nephrolepis exaltata",
-    imageUrl:
-      "https://images.unsplash.com/photo-1619398221730-09294c6d4139?q=80&w=1587&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "High",
-    lightNeed: "Partial Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "Boston Ferns are lush, green plants that thrive in humid environments with bright, indirect light. They need regular watering to keep their fronds healthy.",
-  },
-  {
-    id: "11",
-    name: "Orchid",
-    botanicalName: "Orchidaceae",
-    imageUrl:
-      "https://images.unsplash.com/photo-1454262041357-5d96f50a2f27?q=80&w=1469&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Low",
-    lightNeed: "Partial Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "Orchids are elegant flowering plants that prefer bright, indirect light and minimal watering. They are known for their beautiful and long-lasting blooms.",
-  },
-  {
-    id: "12",
-    name: "Jade Plant",
-    botanicalName: "Crassula ovata",
-    imageUrl:
-      "https://images.unsplash.com/photo-1620127620051-fea30e50c66e?q=80&w=1528&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Low",
-    lightNeed: "Full Sun",
-    fertiliserSeason: ["Spring", "Fall"],
-    description:
-      "The Jade Plant is a succulent known for its thick, fleshy leaves. It thrives in bright light and requires minimal watering, making it easy to care for.",
-  },
-  {
-    id: "13",
-    name: "Philodendron",
-    botanicalName: "Philodendron spp.",
-    imageUrl:
-      "https://images.unsplash.com/photo-1675678964961-4c04733ee34a?q=80&w=1528&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Medium",
-    lightNeed: "Partial Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "Philodendrons are popular houseplants known for their heart-shaped leaves. They prefer indirect light and consistent watering.",
-  },
-  {
-    id: "14",
-    name: "Cactus",
-    botanicalName: "Cactaceae",
-    imageUrl:
-      "https://images.unsplash.com/photo-1497214068716-571605b05ca8?q=80&w=1471&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Low",
-    lightNeed: "Full Sun",
-    fertiliserSeason: ["Summer"],
-    description:
-      "Cacti are desert plants that thrive in bright light and require very little water. They are known for their unique shapes and spines.",
-  },
-  {
-    id: "15",
-    name: "Lavender",
-    botanicalName: "Lavandula",
-    imageUrl:
-      "https://images.unsplash.com/photo-1592685776885-97a964ad8293?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Low",
-    lightNeed: "Full Sun",
-    fertiliserSeason: ["Spring"],
-    description:
-      "Lavender is a fragrant herb known for its purple flowers and soothing scent. It requires full sun and minimal watering.",
-  },
-  {
-    id: "16",
-    name: "Succulent",
-    botanicalName: "Succulents",
-    imageUrl:
-      "https://images.unsplash.com/photo-1509069575671-3df40ce5307c?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Low",
-    lightNeed: "Full Sun",
-    fertiliserSeason: ["Summer", "Fall"],
-    description:
-      "Succulents are a diverse group of plants known for their water-storing capabilities. They thrive in bright light and require minimal watering.",
-  },
-  {
-    id: "17",
-    name: "Calathea",
-    botanicalName: "Calathea spp.",
-    imageUrl:
-      "https://images.unsplash.com/photo-1602879946327-8b4a148c367d?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "High",
-    lightNeed: "Full Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "Calatheas are known for their stunning, patterned leaves. They thrive in low light and high humidity, requiring regular watering to keep their foliage vibrant.",
-  },
-  {
-    id: "18",
-    name: "Yucca",
-    botanicalName: "Yucca",
-    imageUrl:
-      "https://images.unsplash.com/photo-1629516676153-26a76b83701f?q=80&w=1480&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Low",
-    lightNeed: "Full Sun",
-    fertiliserSeason: ["Spring"],
-    description:
-      "Yucca plants are hardy and drought-tolerant, known for their long, sword-shaped leaves. They thrive in bright light and require minimal watering.",
-  },
-  {
-    id: "19",
-    name: "Bamboo",
-    botanicalName: "Bambusoideae",
-    imageUrl:
-      "https://images.unsplash.com/photo-1426020744253-568cd6345e93?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Medium",
-    lightNeed: "Full Sun",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "Bamboo plants are fast-growing and known for their tall, graceful stalks. They prefer bright light and consistent watering, especially during the growing season.",
-  },
-  {
-    id: "20",
-    name: "Anthurium",
-    botanicalName: "Anthurium",
-    imageUrl:
-      "https://images.unsplash.com/photo-1632906379687-355e24798632?q=80&w=1973&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Medium",
-    lightNeed: "Partial Shade",
-    fertiliserSeason: ["Spring", "Fall"],
-    description:
-      "Anthuriums are known for their striking, heart-shaped flowers and glossy leaves. They prefer bright, indirect light and moderate watering.",
-  },
-  {
-    id: "21",
-    name: "English Ivy",
-    botanicalName: "Hedera helix",
-    imageUrl:
-      "https://images.unsplash.com/photo-1724723942347-b113f0cd4a67?q=80&w=2072&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Medium",
-    lightNeed: "Full Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "English Ivy is a versatile plant known for its trailing vines and ability to thrive in shaded areas. It requires moderate watering.",
-  },
-  {
-    id: "22",
-    name: "Dumb Cane",
-    botanicalName: "Dieffenbachia",
-    imageUrl:
-      "https://images.unsplash.com/photo-1631556941887-f81ab0ecfda9?q=80&w=1960&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "High",
-    lightNeed: "Partial Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "Dumb Cane is a popular houseplant known for its large, variegated leaves. It prefers indirect light and regular watering.",
-  },
-  {
-    id: "23",
-    name: "Golden Pothos",
-    botanicalName: "Epipremnum aureum",
-    imageUrl:
-      "https://images.unsplash.com/photo-1674482918961-57a3a0484bf3?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Low",
-    lightNeed: "Partial Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "Golden Pothos is a low-maintenance plant that can thrive in low light and requires infrequent watering. It's known for its trailing vines.",
-  },
-  {
-    id: "24",
-    name: "Peace Lily",
-    botanicalName: "Spathiphyllum",
-    imageUrl:
-      "https://images.unsplash.com/photo-1616694547693-b0f829a6cf30?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8UGVhY2UlMjBMaWx5fGVufDB8MHwwfHx8Mg%3D%3D",
-    waterNeed: "High",
-    lightNeed: "Full Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "Peace Lilies are known for their beautiful white flowers and ability to thrive in low light. They require frequent watering to maintain their lush foliage.",
-  },
-  {
-    id: "25",
-    name: "Areca Palm",
-    botanicalName: "Dypsis lutescens",
-    imageUrl:
-      "https://images.pexels.com/photos/5538833/pexels-photo-5538833.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1",
-    waterNeed: "Medium",
-    lightNeed: "Partial Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "Areca Palms are popular indoor palms known for their feathery, arching fronds. They prefer indirect light and regular watering.",
-  },
-  {
-    id: "26",
-    name: "Swiss Cheese Plant",
-    botanicalName: "Monstera adansonii",
-    imageUrl:
-      "https://images.unsplash.com/photo-1604066538249-f3767aa55545?q=80&w=2074&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Medium",
-    lightNeed: "Partial Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "The Swiss Cheese Plant is known for its unique, perforated leaves. It prefers bright, indirect light and moderate watering.",
-  },
-  {
-    id: "27",
-    name: "Chinese Money Plant",
-    botanicalName: "Pilea peperomioides",
-    imageUrl:
-      "https://images.unsplash.com/photo-1723650879990-dae890387cff?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "Low",
-    lightNeed: "Partial Shade",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "The Chinese Money Plant is a trendy houseplant known for its round, coin-shaped leaves. It thrives in bright, indirect light and requires minimal watering.",
-  },
-  {
-    id: "28",
-    name: "Bird of Paradise",
-    botanicalName: "Strelitzia reginae",
-    imageUrl:
-      "https://images.unsplash.com/photo-1591484599836-a9548b9ebbc8?q=80&w=2031&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-    waterNeed: "High",
-    lightNeed: "Full Sun",
-    fertiliserSeason: ["Spring", "Summer"],
-    description:
-      "Bird of Paradise is known for its striking, tropical flowers. It requires bright light and regular watering to thrive.",
-  },
-  {
-    id: "29",
-    name: "Jade Plant",
-    botanicalName: "Crassula ovata",
-    imageUrl:
-      "https://images.pexels.com/photos/8507297/pexels-photo-8507297.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1",
-    waterNeed: "Low",
-    lightNeed: "Full Sun",
-    fertiliserSeason: ["Spring", "Fall"],
-    description:
-      "The Jade Plant is a succulent known for its thick, fleshy leaves. It thrives in bright light and requires minimal watering, making it easy to care for.",
-  },
+  // {
+  //   id: "1",
+  //   name: "Snake Plant",
+  //   botanicalName: "Sansevieria trifasciata",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1651760548494-4b906ed1600c?q=80&w=2970&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Low",
+  //   lightNeed: "Partial Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "The Snake Plant, also known as Mother-in-Law's Tongue, is a hardy and low-maintenance plant that can thrive in low light and requires minimal watering.",
+  // },
+  // {
+  //   id: "2",
+  //   name: "Fiddle Leaf Fig",
+  //   botanicalName: "Ficus lyrata",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1498766707495-856f300a5821?q=80&w=2971&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Medium",
+  //   lightNeed: "Full Sun",
+  //   fertiliserSeason: ["Spring"],
+  //   description:
+  //     "The Fiddle Leaf Fig is a popular indoor tree known for its large, violin-shaped leaves. It prefers bright, indirect light and consistent watering.",
+  // },
+  // {
+  //   id: "3",
+  //   name: "Aloe Vera",
+  //   botanicalName: "Aloe barbadensis miller",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1702416062979-dc44baa952c1?q=80&w=2970&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Low",
+  //   lightNeed: "Full Sun",
+  //   fertiliserSeason: ["Summer"],
+  //   description:
+  //     "Aloe Vera is a succulent plant species known for its medicinal properties. It requires bright light and minimal water, making it easy to care for.",
+  // },
+  // {
+  //   id: "4",
+  //   name: "Spider Plant",
+  //   botanicalName: "Chlorophytum comosum",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1607363380021-9f1cce0cde24?q=80&w=2970&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Low",
+  //   lightNeed: "Partial Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "The Spider Plant is a resilient houseplant known for its air-purifying qualities and ability to thrive in a variety of light conditions.",
+  // },
+  // {
+  //   id: "5",
+  //   name: "Peace Lily",
+  //   botanicalName: "Spathiphyllum",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1629811119888-dde7186c1fb5?q=80&w=2874&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "High",
+  //   lightNeed: "Full Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "Peace Lilies are known for their beautiful white flowers and ability to thrive in low light. They require frequent watering to maintain their lush foliage.",
+  // },
+  // {
+  //   id: "6",
+  //   name: "Rubber Plant",
+  //   botanicalName: "Ficus elastica",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1643227565928-0cc454ec4937?q=80&w=2874&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Medium",
+  //   lightNeed: "Partial Shade",
+  //   fertiliserSeason: ["Spring", "Fall"],
+  //   description:
+  //     "The Rubber Plant is a popular indoor tree with large, glossy leaves. It thrives in medium to bright light and needs regular watering.",
+  // },
+  // {
+  //   id: "7",
+  //   name: "ZZ Plant",
+  //   botanicalName: "Zamioculcas zamiifolia",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1536882240095-0379873feb4e?q=80&w=2971&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Low",
+  //   lightNeed: "Partial Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "The ZZ Plant is a hardy and drought-tolerant plant that can survive in low light and requires minimal watering, making it perfect for beginners.",
+  // },
+  // {
+  //   id: "8",
+  //   name: "Monstera Deliciosa",
+  //   botanicalName: "Monstera deliciosa",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1545165375-1b744b9ed444?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Medium",
+  //   lightNeed: "Partial Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "Monstera Deliciosa, also known as the Swiss Cheese Plant, is famous for its large, split leaves. It prefers indirect light and moderate watering.",
+  // },
+  // {
+  //   id: "9",
+  //   name: "Pothos",
+  //   botanicalName: "Epipremnum aureum",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1598880940080-ff9a29891b85?q=80&w=1528&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Low",
+  //   lightNeed: "Partial Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "Pothos is a versatile and low-maintenance plant that can thrive in low light and requires infrequent watering. It's known for its trailing vines.",
+  // },
+  // {
+  //   id: "10",
+  //   name: "Boston Fern",
+  //   botanicalName: "Nephrolepis exaltata",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1619398221730-09294c6d4139?q=80&w=1587&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "High",
+  //   lightNeed: "Partial Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "Boston Ferns are lush, green plants that thrive in humid environments with bright, indirect light. They need regular watering to keep their fronds healthy.",
+  // },
+  // {
+  //   id: "11",
+  //   name: "Orchid",
+  //   botanicalName: "Orchidaceae",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1454262041357-5d96f50a2f27?q=80&w=1469&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Low",
+  //   lightNeed: "Partial Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "Orchids are elegant flowering plants that prefer bright, indirect light and minimal watering. They are known for their beautiful and long-lasting blooms.",
+  // },
+  // {
+  //   id: "12",
+  //   name: "Jade Plant",
+  //   botanicalName: "Crassula ovata",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1620127620051-fea30e50c66e?q=80&w=1528&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Low",
+  //   lightNeed: "Full Sun",
+  //   fertiliserSeason: ["Spring", "Fall"],
+  //   description:
+  //     "The Jade Plant is a succulent known for its thick, fleshy leaves. It thrives in bright light and requires minimal watering, making it easy to care for.",
+  // },
+  // {
+  //   id: "13",
+  //   name: "Philodendron",
+  //   botanicalName: "Philodendron spp.",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1675678964961-4c04733ee34a?q=80&w=1528&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Medium",
+  //   lightNeed: "Partial Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "Philodendrons are popular houseplants known for their heart-shaped leaves. They prefer indirect light and consistent watering.",
+  // },
+  // {
+  //   id: "14",
+  //   name: "Cactus",
+  //   botanicalName: "Cactaceae",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1497214068716-571605b05ca8?q=80&w=1471&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Low",
+  //   lightNeed: "Full Sun",
+  //   fertiliserSeason: ["Summer"],
+  //   description:
+  //     "Cacti are desert plants that thrive in bright light and require very little water. They are known for their unique shapes and spines.",
+  // },
+  // {
+  //   id: "15",
+  //   name: "Lavender",
+  //   botanicalName: "Lavandula",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1592685776885-97a964ad8293?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Low",
+  //   lightNeed: "Full Sun",
+  //   fertiliserSeason: ["Spring"],
+  //   description:
+  //     "Lavender is a fragrant herb known for its purple flowers and soothing scent. It requires full sun and minimal watering.",
+  // },
+  // {
+  //   id: "16",
+  //   name: "Succulent",
+  //   botanicalName: "Succulents",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1509069575671-3df40ce5307c?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Low",
+  //   lightNeed: "Full Sun",
+  //   fertiliserSeason: ["Summer", "Fall"],
+  //   description:
+  //     "Succulents are a diverse group of plants known for their water-storing capabilities. They thrive in bright light and require minimal watering.",
+  // },
+  // {
+  //   id: "17",
+  //   name: "Calathea",
+  //   botanicalName: "Calathea spp.",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1602879946327-8b4a148c367d?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "High",
+  //   lightNeed: "Full Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "Calatheas are known for their stunning, patterned leaves. They thrive in low light and high humidity, requiring regular watering to keep their foliage vibrant.",
+  // },
+  // {
+  //   id: "18",
+  //   name: "Yucca",
+  //   botanicalName: "Yucca",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1629516676153-26a76b83701f?q=80&w=1480&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Low",
+  //   lightNeed: "Full Sun",
+  //   fertiliserSeason: ["Spring"],
+  //   description:
+  //     "Yucca plants are hardy and drought-tolerant, known for their long, sword-shaped leaves. They thrive in bright light and require minimal watering.",
+  // },
+  // {
+  //   id: "19",
+  //   name: "Bamboo",
+  //   botanicalName: "Bambusoideae",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1426020744253-568cd6345e93?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Medium",
+  //   lightNeed: "Full Sun",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "Bamboo plants are fast-growing and known for their tall, graceful stalks. They prefer bright light and consistent watering, especially during the growing season.",
+  // },
+  // {
+  //   id: "20",
+  //   name: "Anthurium",
+  //   botanicalName: "Anthurium",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1632906379687-355e24798632?q=80&w=1973&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Medium",
+  //   lightNeed: "Partial Shade",
+  //   fertiliserSeason: ["Spring", "Fall"],
+  //   description:
+  //     "Anthuriums are known for their striking, heart-shaped flowers and glossy leaves. They prefer bright, indirect light and moderate watering.",
+  // },
+  // {
+  //   id: "21",
+  //   name: "English Ivy",
+  //   botanicalName: "Hedera helix",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1724723942347-b113f0cd4a67?q=80&w=2072&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Medium",
+  //   lightNeed: "Full Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "English Ivy is a versatile plant known for its trailing vines and ability to thrive in shaded areas. It requires moderate watering.",
+  // },
+  // {
+  //   id: "22",
+  //   name: "Dumb Cane",
+  //   botanicalName: "Dieffenbachia",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1631556941887-f81ab0ecfda9?q=80&w=1960&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "High",
+  //   lightNeed: "Partial Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "Dumb Cane is a popular houseplant known for its large, variegated leaves. It prefers indirect light and regular watering.",
+  // },
+  // {
+  //   id: "23",
+  //   name: "Golden Pothos",
+  //   botanicalName: "Epipremnum aureum",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1674482918961-57a3a0484bf3?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Low",
+  //   lightNeed: "Partial Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "Golden Pothos is a low-maintenance plant that can thrive in low light and requires infrequent watering. It's known for its trailing vines.",
+  // },
+  // {
+  //   id: "24",
+  //   name: "Peace Lily",
+  //   botanicalName: "Spathiphyllum",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1616694547693-b0f829a6cf30?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8UGVhY2UlMjBMaWx5fGVufDB8MHwwfHx8Mg%3D%3D",
+  //   waterNeed: "High",
+  //   lightNeed: "Full Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "Peace Lilies are known for their beautiful white flowers and ability to thrive in low light. They require frequent watering to maintain their lush foliage.",
+  // },
+  // {
+  //   id: "25",
+  //   name: "Areca Palm",
+  //   botanicalName: "Dypsis lutescens",
+  //   imageUrl:
+  //     "https://images.pexels.com/photos/5538833/pexels-photo-5538833.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1",
+  //   waterNeed: "Medium",
+  //   lightNeed: "Partial Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "Areca Palms are popular indoor palms known for their feathery, arching fronds. They prefer indirect light and regular watering.",
+  // },
+  // {
+  //   id: "26",
+  //   name: "Swiss Cheese Plant",
+  //   botanicalName: "Monstera adansonii",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1604066538249-f3767aa55545?q=80&w=2074&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Medium",
+  //   lightNeed: "Partial Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "The Swiss Cheese Plant is known for its unique, perforated leaves. It prefers bright, indirect light and moderate watering.",
+  // },
+  // {
+  //   id: "27",
+  //   name: "Chinese Money Plant",
+  //   botanicalName: "Pilea peperomioides",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1723650879990-dae890387cff?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "Low",
+  //   lightNeed: "Partial Shade",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "The Chinese Money Plant is a trendy houseplant known for its round, coin-shaped leaves. It thrives in bright, indirect light and requires minimal watering.",
+  // },
+  // {
+  //   id: "28",
+  //   name: "Bird of Paradise",
+  //   botanicalName: "Strelitzia reginae",
+  //   imageUrl:
+  //     "https://images.unsplash.com/photo-1591484599836-a9548b9ebbc8?q=80&w=2031&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  //   waterNeed: "High",
+  //   lightNeed: "Full Sun",
+  //   fertiliserSeason: ["Spring", "Summer"],
+  //   description:
+  //     "Bird of Paradise is known for its striking, tropical flowers. It requires bright light and regular watering to thrive.",
+  // },
+  // {
+  //   id: "29",
+  //   name: "Jade Plant",
+  //   botanicalName: "Crassula ovata",
+  //   imageUrl:
+  //     "https://images.pexels.com/photos/8507297/pexels-photo-8507297.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1",
+  //   waterNeed: "Low",
+  //   lightNeed: "Full Sun",
+  //   fertiliserSeason: ["Spring", "Fall"],
+  //   description:
+  //     "The Jade Plant is a succulent known for its thick, fleshy leaves. It thrives in bright light and requires minimal watering, making it easy to care for.",
+  // },
   {
     id: "30",
     name: "African Violet",

--- a/lib/data.js
+++ b/lib/data.js
@@ -1,352 +1,352 @@
 export const plants = [
-  // {
-  //   id: "1",
-  //   name: "Snake Plant",
-  //   botanicalName: "Sansevieria trifasciata",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1651760548494-4b906ed1600c?q=80&w=2970&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Low",
-  //   lightNeed: "Partial Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "The Snake Plant, also known as Mother-in-Law's Tongue, is a hardy and low-maintenance plant that can thrive in low light and requires minimal watering.",
-  // },
-  // {
-  //   id: "2",
-  //   name: "Fiddle Leaf Fig",
-  //   botanicalName: "Ficus lyrata",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1498766707495-856f300a5821?q=80&w=2971&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Medium",
-  //   lightNeed: "Full Sun",
-  //   fertiliserSeason: ["Spring"],
-  //   description:
-  //     "The Fiddle Leaf Fig is a popular indoor tree known for its large, violin-shaped leaves. It prefers bright, indirect light and consistent watering.",
-  // },
-  // {
-  //   id: "3",
-  //   name: "Aloe Vera",
-  //   botanicalName: "Aloe barbadensis miller",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1702416062979-dc44baa952c1?q=80&w=2970&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Low",
-  //   lightNeed: "Full Sun",
-  //   fertiliserSeason: ["Summer"],
-  //   description:
-  //     "Aloe Vera is a succulent plant species known for its medicinal properties. It requires bright light and minimal water, making it easy to care for.",
-  // },
-  // {
-  //   id: "4",
-  //   name: "Spider Plant",
-  //   botanicalName: "Chlorophytum comosum",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1607363380021-9f1cce0cde24?q=80&w=2970&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Low",
-  //   lightNeed: "Partial Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "The Spider Plant is a resilient houseplant known for its air-purifying qualities and ability to thrive in a variety of light conditions.",
-  // },
-  // {
-  //   id: "5",
-  //   name: "Peace Lily",
-  //   botanicalName: "Spathiphyllum",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1629811119888-dde7186c1fb5?q=80&w=2874&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "High",
-  //   lightNeed: "Full Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "Peace Lilies are known for their beautiful white flowers and ability to thrive in low light. They require frequent watering to maintain their lush foliage.",
-  // },
-  // {
-  //   id: "6",
-  //   name: "Rubber Plant",
-  //   botanicalName: "Ficus elastica",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1643227565928-0cc454ec4937?q=80&w=2874&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Medium",
-  //   lightNeed: "Partial Shade",
-  //   fertiliserSeason: ["Spring", "Fall"],
-  //   description:
-  //     "The Rubber Plant is a popular indoor tree with large, glossy leaves. It thrives in medium to bright light and needs regular watering.",
-  // },
-  // {
-  //   id: "7",
-  //   name: "ZZ Plant",
-  //   botanicalName: "Zamioculcas zamiifolia",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1536882240095-0379873feb4e?q=80&w=2971&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Low",
-  //   lightNeed: "Partial Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "The ZZ Plant is a hardy and drought-tolerant plant that can survive in low light and requires minimal watering, making it perfect for beginners.",
-  // },
-  // {
-  //   id: "8",
-  //   name: "Monstera Deliciosa",
-  //   botanicalName: "Monstera deliciosa",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1545165375-1b744b9ed444?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Medium",
-  //   lightNeed: "Partial Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "Monstera Deliciosa, also known as the Swiss Cheese Plant, is famous for its large, split leaves. It prefers indirect light and moderate watering.",
-  // },
-  // {
-  //   id: "9",
-  //   name: "Pothos",
-  //   botanicalName: "Epipremnum aureum",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1598880940080-ff9a29891b85?q=80&w=1528&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Low",
-  //   lightNeed: "Partial Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "Pothos is a versatile and low-maintenance plant that can thrive in low light and requires infrequent watering. It's known for its trailing vines.",
-  // },
-  // {
-  //   id: "10",
-  //   name: "Boston Fern",
-  //   botanicalName: "Nephrolepis exaltata",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1619398221730-09294c6d4139?q=80&w=1587&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "High",
-  //   lightNeed: "Partial Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "Boston Ferns are lush, green plants that thrive in humid environments with bright, indirect light. They need regular watering to keep their fronds healthy.",
-  // },
-  // {
-  //   id: "11",
-  //   name: "Orchid",
-  //   botanicalName: "Orchidaceae",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1454262041357-5d96f50a2f27?q=80&w=1469&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Low",
-  //   lightNeed: "Partial Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "Orchids are elegant flowering plants that prefer bright, indirect light and minimal watering. They are known for their beautiful and long-lasting blooms.",
-  // },
-  // {
-  //   id: "12",
-  //   name: "Jade Plant",
-  //   botanicalName: "Crassula ovata",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1620127620051-fea30e50c66e?q=80&w=1528&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Low",
-  //   lightNeed: "Full Sun",
-  //   fertiliserSeason: ["Spring", "Fall"],
-  //   description:
-  //     "The Jade Plant is a succulent known for its thick, fleshy leaves. It thrives in bright light and requires minimal watering, making it easy to care for.",
-  // },
-  // {
-  //   id: "13",
-  //   name: "Philodendron",
-  //   botanicalName: "Philodendron spp.",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1675678964961-4c04733ee34a?q=80&w=1528&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Medium",
-  //   lightNeed: "Partial Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "Philodendrons are popular houseplants known for their heart-shaped leaves. They prefer indirect light and consistent watering.",
-  // },
-  // {
-  //   id: "14",
-  //   name: "Cactus",
-  //   botanicalName: "Cactaceae",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1497214068716-571605b05ca8?q=80&w=1471&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Low",
-  //   lightNeed: "Full Sun",
-  //   fertiliserSeason: ["Summer"],
-  //   description:
-  //     "Cacti are desert plants that thrive in bright light and require very little water. They are known for their unique shapes and spines.",
-  // },
-  // {
-  //   id: "15",
-  //   name: "Lavender",
-  //   botanicalName: "Lavandula",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1592685776885-97a964ad8293?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Low",
-  //   lightNeed: "Full Sun",
-  //   fertiliserSeason: ["Spring"],
-  //   description:
-  //     "Lavender is a fragrant herb known for its purple flowers and soothing scent. It requires full sun and minimal watering.",
-  // },
-  // {
-  //   id: "16",
-  //   name: "Succulent",
-  //   botanicalName: "Succulents",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1509069575671-3df40ce5307c?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Low",
-  //   lightNeed: "Full Sun",
-  //   fertiliserSeason: ["Summer", "Fall"],
-  //   description:
-  //     "Succulents are a diverse group of plants known for their water-storing capabilities. They thrive in bright light and require minimal watering.",
-  // },
-  // {
-  //   id: "17",
-  //   name: "Calathea",
-  //   botanicalName: "Calathea spp.",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1602879946327-8b4a148c367d?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "High",
-  //   lightNeed: "Full Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "Calatheas are known for their stunning, patterned leaves. They thrive in low light and high humidity, requiring regular watering to keep their foliage vibrant.",
-  // },
-  // {
-  //   id: "18",
-  //   name: "Yucca",
-  //   botanicalName: "Yucca",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1629516676153-26a76b83701f?q=80&w=1480&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Low",
-  //   lightNeed: "Full Sun",
-  //   fertiliserSeason: ["Spring"],
-  //   description:
-  //     "Yucca plants are hardy and drought-tolerant, known for their long, sword-shaped leaves. They thrive in bright light and require minimal watering.",
-  // },
-  // {
-  //   id: "19",
-  //   name: "Bamboo",
-  //   botanicalName: "Bambusoideae",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1426020744253-568cd6345e93?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Medium",
-  //   lightNeed: "Full Sun",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "Bamboo plants are fast-growing and known for their tall, graceful stalks. They prefer bright light and consistent watering, especially during the growing season.",
-  // },
-  // {
-  //   id: "20",
-  //   name: "Anthurium",
-  //   botanicalName: "Anthurium",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1632906379687-355e24798632?q=80&w=1973&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Medium",
-  //   lightNeed: "Partial Shade",
-  //   fertiliserSeason: ["Spring", "Fall"],
-  //   description:
-  //     "Anthuriums are known for their striking, heart-shaped flowers and glossy leaves. They prefer bright, indirect light and moderate watering.",
-  // },
-  // {
-  //   id: "21",
-  //   name: "English Ivy",
-  //   botanicalName: "Hedera helix",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1724723942347-b113f0cd4a67?q=80&w=2072&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Medium",
-  //   lightNeed: "Full Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "English Ivy is a versatile plant known for its trailing vines and ability to thrive in shaded areas. It requires moderate watering.",
-  // },
-  // {
-  //   id: "22",
-  //   name: "Dumb Cane",
-  //   botanicalName: "Dieffenbachia",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1631556941887-f81ab0ecfda9?q=80&w=1960&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "High",
-  //   lightNeed: "Partial Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "Dumb Cane is a popular houseplant known for its large, variegated leaves. It prefers indirect light and regular watering.",
-  // },
-  // {
-  //   id: "23",
-  //   name: "Golden Pothos",
-  //   botanicalName: "Epipremnum aureum",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1674482918961-57a3a0484bf3?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Low",
-  //   lightNeed: "Partial Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "Golden Pothos is a low-maintenance plant that can thrive in low light and requires infrequent watering. It's known for its trailing vines.",
-  // },
-  // {
-  //   id: "24",
-  //   name: "Peace Lily",
-  //   botanicalName: "Spathiphyllum",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1616694547693-b0f829a6cf30?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8UGVhY2UlMjBMaWx5fGVufDB8MHwwfHx8Mg%3D%3D",
-  //   waterNeed: "High",
-  //   lightNeed: "Full Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "Peace Lilies are known for their beautiful white flowers and ability to thrive in low light. They require frequent watering to maintain their lush foliage.",
-  // },
-  // {
-  //   id: "25",
-  //   name: "Areca Palm",
-  //   botanicalName: "Dypsis lutescens",
-  //   imageUrl:
-  //     "https://images.pexels.com/photos/5538833/pexels-photo-5538833.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1",
-  //   waterNeed: "Medium",
-  //   lightNeed: "Partial Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "Areca Palms are popular indoor palms known for their feathery, arching fronds. They prefer indirect light and regular watering.",
-  // },
-  // {
-  //   id: "26",
-  //   name: "Swiss Cheese Plant",
-  //   botanicalName: "Monstera adansonii",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1604066538249-f3767aa55545?q=80&w=2074&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Medium",
-  //   lightNeed: "Partial Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "The Swiss Cheese Plant is known for its unique, perforated leaves. It prefers bright, indirect light and moderate watering.",
-  // },
-  // {
-  //   id: "27",
-  //   name: "Chinese Money Plant",
-  //   botanicalName: "Pilea peperomioides",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1723650879990-dae890387cff?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "Low",
-  //   lightNeed: "Partial Shade",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "The Chinese Money Plant is a trendy houseplant known for its round, coin-shaped leaves. It thrives in bright, indirect light and requires minimal watering.",
-  // },
-  // {
-  //   id: "28",
-  //   name: "Bird of Paradise",
-  //   botanicalName: "Strelitzia reginae",
-  //   imageUrl:
-  //     "https://images.unsplash.com/photo-1591484599836-a9548b9ebbc8?q=80&w=2031&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-  //   waterNeed: "High",
-  //   lightNeed: "Full Sun",
-  //   fertiliserSeason: ["Spring", "Summer"],
-  //   description:
-  //     "Bird of Paradise is known for its striking, tropical flowers. It requires bright light and regular watering to thrive.",
-  // },
-  // {
-  //   id: "29",
-  //   name: "Jade Plant",
-  //   botanicalName: "Crassula ovata",
-  //   imageUrl:
-  //     "https://images.pexels.com/photos/8507297/pexels-photo-8507297.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1",
-  //   waterNeed: "Low",
-  //   lightNeed: "Full Sun",
-  //   fertiliserSeason: ["Spring", "Fall"],
-  //   description:
-  //     "The Jade Plant is a succulent known for its thick, fleshy leaves. It thrives in bright light and requires minimal watering, making it easy to care for.",
-  // },
+  {
+    id: "1",
+    name: "Snake Plant",
+    botanicalName: "Sansevieria trifasciata",
+    imageUrl:
+      "https://images.unsplash.com/photo-1651760548494-4b906ed1600c?q=80&w=2970&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Low",
+    lightNeed: "Partial Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "The Snake Plant, also known as Mother-in-Law's Tongue, is a hardy and low-maintenance plant that can thrive in low light and requires minimal watering.",
+  },
+  {
+    id: "2",
+    name: "Fiddle Leaf Fig",
+    botanicalName: "Ficus lyrata",
+    imageUrl:
+      "https://images.unsplash.com/photo-1498766707495-856f300a5821?q=80&w=2971&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Medium",
+    lightNeed: "Full Sun",
+    fertiliserSeason: ["Spring"],
+    description:
+      "The Fiddle Leaf Fig is a popular indoor tree known for its large, violin-shaped leaves. It prefers bright, indirect light and consistent watering.",
+  },
+  {
+    id: "3",
+    name: "Aloe Vera",
+    botanicalName: "Aloe barbadensis miller",
+    imageUrl:
+      "https://images.unsplash.com/photo-1702416062979-dc44baa952c1?q=80&w=2970&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Low",
+    lightNeed: "Full Sun",
+    fertiliserSeason: ["Summer"],
+    description:
+      "Aloe Vera is a succulent plant species known for its medicinal properties. It requires bright light and minimal water, making it easy to care for.",
+  },
+  {
+    id: "4",
+    name: "Spider Plant",
+    botanicalName: "Chlorophytum comosum",
+    imageUrl:
+      "https://images.unsplash.com/photo-1607363380021-9f1cce0cde24?q=80&w=2970&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Low",
+    lightNeed: "Partial Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "The Spider Plant is a resilient houseplant known for its air-purifying qualities and ability to thrive in a variety of light conditions.",
+  },
+  {
+    id: "5",
+    name: "Peace Lily",
+    botanicalName: "Spathiphyllum",
+    imageUrl:
+      "https://images.unsplash.com/photo-1629811119888-dde7186c1fb5?q=80&w=2874&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "High",
+    lightNeed: "Full Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "Peace Lilies are known for their beautiful white flowers and ability to thrive in low light. They require frequent watering to maintain their lush foliage.",
+  },
+  {
+    id: "6",
+    name: "Rubber Plant",
+    botanicalName: "Ficus elastica",
+    imageUrl:
+      "https://images.unsplash.com/photo-1643227565928-0cc454ec4937?q=80&w=2874&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Medium",
+    lightNeed: "Partial Shade",
+    fertiliserSeason: ["Spring", "Fall"],
+    description:
+      "The Rubber Plant is a popular indoor tree with large, glossy leaves. It thrives in medium to bright light and needs regular watering.",
+  },
+  {
+    id: "7",
+    name: "ZZ Plant",
+    botanicalName: "Zamioculcas zamiifolia",
+    imageUrl:
+      "https://images.unsplash.com/photo-1536882240095-0379873feb4e?q=80&w=2971&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Low",
+    lightNeed: "Partial Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "The ZZ Plant is a hardy and drought-tolerant plant that can survive in low light and requires minimal watering, making it perfect for beginners.",
+  },
+  {
+    id: "8",
+    name: "Monstera Deliciosa",
+    botanicalName: "Monstera deliciosa",
+    imageUrl:
+      "https://images.unsplash.com/photo-1545165375-1b744b9ed444?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Medium",
+    lightNeed: "Partial Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "Monstera Deliciosa, also known as the Swiss Cheese Plant, is famous for its large, split leaves. It prefers indirect light and moderate watering.",
+  },
+  {
+    id: "9",
+    name: "Pothos",
+    botanicalName: "Epipremnum aureum",
+    imageUrl:
+      "https://images.unsplash.com/photo-1598880940080-ff9a29891b85?q=80&w=1528&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Low",
+    lightNeed: "Partial Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "Pothos is a versatile and low-maintenance plant that can thrive in low light and requires infrequent watering. It's known for its trailing vines.",
+  },
+  {
+    id: "10",
+    name: "Boston Fern",
+    botanicalName: "Nephrolepis exaltata",
+    imageUrl:
+      "https://images.unsplash.com/photo-1619398221730-09294c6d4139?q=80&w=1587&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "High",
+    lightNeed: "Partial Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "Boston Ferns are lush, green plants that thrive in humid environments with bright, indirect light. They need regular watering to keep their fronds healthy.",
+  },
+  {
+    id: "11",
+    name: "Orchid",
+    botanicalName: "Orchidaceae",
+    imageUrl:
+      "https://images.unsplash.com/photo-1454262041357-5d96f50a2f27?q=80&w=1469&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Low",
+    lightNeed: "Partial Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "Orchids are elegant flowering plants that prefer bright, indirect light and minimal watering. They are known for their beautiful and long-lasting blooms.",
+  },
+  {
+    id: "12",
+    name: "Jade Plant",
+    botanicalName: "Crassula ovata",
+    imageUrl:
+      "https://images.unsplash.com/photo-1620127620051-fea30e50c66e?q=80&w=1528&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Low",
+    lightNeed: "Full Sun",
+    fertiliserSeason: ["Spring", "Fall"],
+    description:
+      "The Jade Plant is a succulent known for its thick, fleshy leaves. It thrives in bright light and requires minimal watering, making it easy to care for.",
+  },
+  {
+    id: "13",
+    name: "Philodendron",
+    botanicalName: "Philodendron spp.",
+    imageUrl:
+      "https://images.unsplash.com/photo-1675678964961-4c04733ee34a?q=80&w=1528&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Medium",
+    lightNeed: "Partial Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "Philodendrons are popular houseplants known for their heart-shaped leaves. They prefer indirect light and consistent watering.",
+  },
+  {
+    id: "14",
+    name: "Cactus",
+    botanicalName: "Cactaceae",
+    imageUrl:
+      "https://images.unsplash.com/photo-1497214068716-571605b05ca8?q=80&w=1471&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Low",
+    lightNeed: "Full Sun",
+    fertiliserSeason: ["Summer"],
+    description:
+      "Cacti are desert plants that thrive in bright light and require very little water. They are known for their unique shapes and spines.",
+  },
+  {
+    id: "15",
+    name: "Lavender",
+    botanicalName: "Lavandula",
+    imageUrl:
+      "https://images.unsplash.com/photo-1592685776885-97a964ad8293?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Low",
+    lightNeed: "Full Sun",
+    fertiliserSeason: ["Spring"],
+    description:
+      "Lavender is a fragrant herb known for its purple flowers and soothing scent. It requires full sun and minimal watering.",
+  },
+  {
+    id: "16",
+    name: "Succulent",
+    botanicalName: "Succulents",
+    imageUrl:
+      "https://images.unsplash.com/photo-1509069575671-3df40ce5307c?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Low",
+    lightNeed: "Full Sun",
+    fertiliserSeason: ["Summer", "Fall"],
+    description:
+      "Succulents are a diverse group of plants known for their water-storing capabilities. They thrive in bright light and require minimal watering.",
+  },
+  {
+    id: "17",
+    name: "Calathea",
+    botanicalName: "Calathea spp.",
+    imageUrl:
+      "https://images.unsplash.com/photo-1602879946327-8b4a148c367d?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "High",
+    lightNeed: "Full Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "Calatheas are known for their stunning, patterned leaves. They thrive in low light and high humidity, requiring regular watering to keep their foliage vibrant.",
+  },
+  {
+    id: "18",
+    name: "Yucca",
+    botanicalName: "Yucca",
+    imageUrl:
+      "https://images.unsplash.com/photo-1629516676153-26a76b83701f?q=80&w=1480&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Low",
+    lightNeed: "Full Sun",
+    fertiliserSeason: ["Spring"],
+    description:
+      "Yucca plants are hardy and drought-tolerant, known for their long, sword-shaped leaves. They thrive in bright light and require minimal watering.",
+  },
+  {
+    id: "19",
+    name: "Bamboo",
+    botanicalName: "Bambusoideae",
+    imageUrl:
+      "https://images.unsplash.com/photo-1426020744253-568cd6345e93?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Medium",
+    lightNeed: "Full Sun",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "Bamboo plants are fast-growing and known for their tall, graceful stalks. They prefer bright light and consistent watering, especially during the growing season.",
+  },
+  {
+    id: "20",
+    name: "Anthurium",
+    botanicalName: "Anthurium",
+    imageUrl:
+      "https://images.unsplash.com/photo-1632906379687-355e24798632?q=80&w=1973&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Medium",
+    lightNeed: "Partial Shade",
+    fertiliserSeason: ["Spring", "Fall"],
+    description:
+      "Anthuriums are known for their striking, heart-shaped flowers and glossy leaves. They prefer bright, indirect light and moderate watering.",
+  },
+  {
+    id: "21",
+    name: "English Ivy",
+    botanicalName: "Hedera helix",
+    imageUrl:
+      "https://images.unsplash.com/photo-1724723942347-b113f0cd4a67?q=80&w=2072&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Medium",
+    lightNeed: "Full Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "English Ivy is a versatile plant known for its trailing vines and ability to thrive in shaded areas. It requires moderate watering.",
+  },
+  {
+    id: "22",
+    name: "Dumb Cane",
+    botanicalName: "Dieffenbachia",
+    imageUrl:
+      "https://images.unsplash.com/photo-1631556941887-f81ab0ecfda9?q=80&w=1960&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "High",
+    lightNeed: "Partial Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "Dumb Cane is a popular houseplant known for its large, variegated leaves. It prefers indirect light and regular watering.",
+  },
+  {
+    id: "23",
+    name: "Golden Pothos",
+    botanicalName: "Epipremnum aureum",
+    imageUrl:
+      "https://images.unsplash.com/photo-1674482918961-57a3a0484bf3?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Low",
+    lightNeed: "Partial Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "Golden Pothos is a low-maintenance plant that can thrive in low light and requires infrequent watering. It's known for its trailing vines.",
+  },
+  {
+    id: "24",
+    name: "Peace Lily",
+    botanicalName: "Spathiphyllum",
+    imageUrl:
+      "https://images.unsplash.com/photo-1616694547693-b0f829a6cf30?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8UGVhY2UlMjBMaWx5fGVufDB8MHwwfHx8Mg%3D%3D",
+    waterNeed: "High",
+    lightNeed: "Full Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "Peace Lilies are known for their beautiful white flowers and ability to thrive in low light. They require frequent watering to maintain their lush foliage.",
+  },
+  {
+    id: "25",
+    name: "Areca Palm",
+    botanicalName: "Dypsis lutescens",
+    imageUrl:
+      "https://images.pexels.com/photos/5538833/pexels-photo-5538833.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1",
+    waterNeed: "Medium",
+    lightNeed: "Partial Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "Areca Palms are popular indoor palms known for their feathery, arching fronds. They prefer indirect light and regular watering.",
+  },
+  {
+    id: "26",
+    name: "Swiss Cheese Plant",
+    botanicalName: "Monstera adansonii",
+    imageUrl:
+      "https://images.unsplash.com/photo-1604066538249-f3767aa55545?q=80&w=2074&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Medium",
+    lightNeed: "Partial Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "The Swiss Cheese Plant is known for its unique, perforated leaves. It prefers bright, indirect light and moderate watering.",
+  },
+  {
+    id: "27",
+    name: "Chinese Money Plant",
+    botanicalName: "Pilea peperomioides",
+    imageUrl:
+      "https://images.unsplash.com/photo-1723650879990-dae890387cff?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "Low",
+    lightNeed: "Partial Shade",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "The Chinese Money Plant is a trendy houseplant known for its round, coin-shaped leaves. It thrives in bright, indirect light and requires minimal watering.",
+  },
+  {
+    id: "28",
+    name: "Bird of Paradise",
+    botanicalName: "Strelitzia reginae",
+    imageUrl:
+      "https://images.unsplash.com/photo-1591484599836-a9548b9ebbc8?q=80&w=2031&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    waterNeed: "High",
+    lightNeed: "Full Sun",
+    fertiliserSeason: ["Spring", "Summer"],
+    description:
+      "Bird of Paradise is known for its striking, tropical flowers. It requires bright light and regular watering to thrive.",
+  },
+  {
+    id: "29",
+    name: "Jade Plant",
+    botanicalName: "Crassula ovata",
+    imageUrl:
+      "https://images.pexels.com/photos/8507297/pexels-photo-8507297.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1",
+    waterNeed: "Low",
+    lightNeed: "Full Sun",
+    fertiliserSeason: ["Spring", "Fall"],
+    description:
+      "The Jade Plant is a succulent known for its thick, fleshy leaves. It thrives in bright light and requires minimal watering, making it easy to care for.",
+  },
   {
     id: "30",
     name: "African Violet",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-icons": "^5.3.0",
-        "styled-components": "^6.0.2",
+        "styled-components": "^6.1.13",
         "use-local-storage-state": "^19.4.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-icons": "^5.3.0",
-    "styled-components": "^6.0.2",
+    "styled-components": "^6.1.13",
     "use-local-storage-state": "^19.4.1"
   },
   "devDependencies": {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -16,6 +16,10 @@ export default function App({ Component, pageProps }) {
     );
   }
 
+  function onDeletePlant() {
+    return console.log("Deleted!");
+  }
+
   return (
     <>
       <GlobalStyle />
@@ -26,6 +30,7 @@ export default function App({ Component, pageProps }) {
         {...pageProps}
         handleToggleOwned={handleToggleOwned}
         plants={plants}
+        onDeletePlant={onDeletePlant}
       />
     </>
   );

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,8 +2,11 @@ import GlobalStyle from "../styles";
 import Image from "next/image";
 import { plants as initialPlants } from "/lib/data";
 import useLocalStorageState from "use-local-storage-state";
+import { useRouter } from "next/router";
 
 export default function App({ Component, pageProps }) {
+  const router = useRouter();
+
   const [plants, setPlants] = useLocalStorageState("plants", {
     defaultValue: initialPlants,
   });
@@ -16,8 +19,15 @@ export default function App({ Component, pageProps }) {
     );
   }
 
-  function onDeletePlant() {
-    return console.log("Deleted!");
+  console.log(plants);
+
+  function handleDeletePlant(id) {
+    setPlants((prevPlants) => 
+      prevPlants.filter((plant) =>
+        plant.id !== id)
+    );
+    
+    router.push("/");
   }
 
   return (
@@ -30,7 +40,7 @@ export default function App({ Component, pageProps }) {
         {...pageProps}
         handleToggleOwned={handleToggleOwned}
         plants={plants}
-        onDeletePlant={onDeletePlant}
+        onDeletePlant={handleDeletePlant}
       />
     </>
   );

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -19,14 +19,12 @@ export default function App({ Component, pageProps }) {
     );
   }
 
-  console.log(plants);
-
   function handleDeletePlant(id) {
     setPlants((prevPlants) => 
       prevPlants.filter((plant) =>
         plant.id !== id)
     );
-    
+
     router.push("/");
   }
 

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -3,7 +3,7 @@ import Image from "next/image";
 import { plants as initialPlants } from "/lib/data";
 import useLocalStorageState from "use-local-storage-state";
 import { useRouter } from "next/router";
-import { nanoid } from 'nanoid'
+import { nanoid } from 'nanoid';
 
 
 export default function App({ Component, pageProps }) {

--- a/pages/index.js
+++ b/pages/index.js
@@ -15,21 +15,23 @@ export default function HomePage({ handleToggleOwned, plants, handleAddPlant }) 
           <StyledButton type="button">Add Plant</StyledButton>
         </>
       ) : (
-      <AddPlantForm handleAddPlant={handleAddPlant}/>
-      <ul>
-        {plants.map((plant) => (
-          <li key={plant.id}>
-            <PlantCard
-              plantId={plant.id}
-              image={plant.imageUrl}
-              name={plant.name}
-              botanicalName={plant.botanicalName}
-              handleToggleOwned={handleToggleOwned}
-              isOwned={plant.isOwned}
-            />
-          </li>
-        ))}
-      </ul>
+        <>
+          <AddPlantForm handleAddPlant={handleAddPlant}/>
+          <ul>
+            {plants.map((plant) => (
+              <li key={plant.id}>
+                <PlantCard
+                  plantId={plant.id}
+                  image={plant.imageUrl}
+                  name={plant.name}
+                  botanicalName={plant.botanicalName}
+                  handleToggleOwned={handleToggleOwned}
+                  isOwned={plant.isOwned}
+                />
+              </li>
+            ))}
+          </ul>
+        </>
       )}
       <Link href="/myplants">My Plants</Link>
     </main>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,22 +1,19 @@
 import PlantCard from "/components/PlantCard";
 import Link from "next/link";
+import styled from "styled-components";
 
 export default function HomePage({ handleToggleOwned, plants }) {
-
-  if(plants.length === 0) {
-    return (
-    <main>
-    <h1>Plant List</h1>
-    <p>No plants there yet. Add new ones!</p>
-    <br />
-    <button type="button">Add Plant</button>
-  </main>
-    )
-  }
 
   return (
     <main>
       <h1>Plant List</h1>
+      { plants.length === 0 ? (
+        <>
+          <StyledInfoText>No plants there yet. Add new ones!</StyledInfoText>
+          <br />
+          <button type="button">Add Plant</button>
+        </>
+      ) : (
       <ul>
         {plants.map((plant) => (
           <li key={plant.id}>
@@ -31,10 +28,20 @@ export default function HomePage({ handleToggleOwned, plants }) {
           </li>
         ))}
       </ul>
+      )}
       <Link href="/myplants">My Plants</Link>
     </main>
   );
 }
+
+
+const StyledInfoText = styled.p`
+  color: var(--green-main);
+  background-color: var(--gray);
+  margin-top: 10px;
+  padding: 40px 40px;
+  border-radius: 25px;
+`;
 
 
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -11,7 +11,8 @@ export default function HomePage({ handleToggleOwned, plants }) {
         <>
           <StyledInfoText>No plants there yet. Add new ones!</StyledInfoText>
           <br />
-          <button type="button">Add Plant</button>
+          <StyledButton type="button">Add Plant</StyledButton>
+          <br />
         </>
       ) : (
       <ul>
@@ -44,5 +45,11 @@ const StyledInfoText = styled.p`
 `;
 
 
+const StyledButton = styled.button`
+    background-color: var(--green-light);
+    padding: 8px 20px;
+    border: none;
+    border-radius: 20px;
+`;
 
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -10,9 +10,7 @@ export default function HomePage({ handleToggleOwned, plants }) {
       { plants.length === 0 ? (
         <>
           <StyledInfoText>No plants there yet. Add new ones!</StyledInfoText>
-          <br />
           <StyledButton type="button">Add Plant</StyledButton>
-          <br />
         </>
       ) : (
       <ul>
@@ -40,7 +38,7 @@ const StyledInfoText = styled.p`
   color: var(--green-main);
   background-color: var(--gray);
   margin-top: 10px;
-  padding: 40px 40px;
+  padding: 40px;
   border-radius: 25px;
 `;
 
@@ -50,6 +48,7 @@ const StyledButton = styled.button`
     padding: 8px 20px;
     border: none;
     border-radius: 20px;
+    margin: 10px 0;
 `;
 
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,6 +2,18 @@ import PlantCard from "/components/PlantCard";
 import Link from "next/link";
 
 export default function HomePage({ handleToggleOwned, plants }) {
+
+  if(plants.length === 0) {
+    return (
+    <main>
+    <h1>Plant List</h1>
+    <p>No plants there yet. Add new ones!</p>
+    <br />
+    <button type="button">Add Plant</button>
+  </main>
+    )
+  }
+
   return (
     <main>
       <h1>Plant List</h1>
@@ -23,3 +35,7 @@ export default function HomePage({ handleToggleOwned, plants }) {
     </main>
   );
 }
+
+
+
+

--- a/pages/plants/[id].js
+++ b/pages/plants/[id].js
@@ -15,7 +15,7 @@ export default function PlantDetailsPage({ plants, onDeletePlant }) {
   return (
     <main>
       <h1>Plant Details</h1>
-      <PlantDetails {...plant} onDeletePlant={onDeletePlant} />
+      <PlantDetails {...plant} onDeletePlant={onDeletePlant} id={id} />
     </main>
   );
 }

--- a/pages/plants/[id].js
+++ b/pages/plants/[id].js
@@ -1,7 +1,7 @@
 import { useRouter } from "next/router";
 import PlantDetails from "/components/PlantDetails/PlantDetails";
 
-export default function PlantDetailsPage({ plants }) {
+export default function PlantDetailsPage({ plants, onDeletePlant }) {
   const router = useRouter();
 
   const { id } = router.query;
@@ -15,7 +15,7 @@ export default function PlantDetailsPage({ plants }) {
   return (
     <main>
       <h1>Plant Details</h1>
-      <PlantDetails {...plant} />
+      <PlantDetails {...plant} onDeletePlant={onDeletePlant} />
     </main>
   );
 }


### PR DESCRIPTION
**#5 delete plant**
This feature enables users to delete plants that are no longer relevant.

To achieve this, we:

- Created a `PlantDeleteButton` component that let users click a 'delete' button which is located on the Details Page of a plant
- Implemented a confirmation dialog which opens after clicking the delete button by a simple toggle function
- Added a 'cancel' and 'delete' button on the confirmation dialog 
-  Developed a handle delete function for the `plants`-state, with `router.push` to navigate back to the Homepage  upon deletion
- Set up an info text on Homepage that displays only if all plants are deleted