### PR TITLE
Stephan feature 10 clickable plantcard

### DIFF
--- a/components/PlantCard/index.js
+++ b/components/PlantCard/index.js
@@ -22,8 +22,10 @@ export default function PlantCard({
         />
         <StyledImage src={image} alt={name} fill={true} />
       </StyledImageContainer>    
+      <StyledCardTitleContainer>
         <StyledH2>{name}</StyledH2>
         <StyledH3>{botanicalName}</StyledH3>
+        </StyledCardTitleContainer>
       </Link>
     </StyledCard>
   );
@@ -36,10 +38,13 @@ const StyledCard = styled.article`
   border-radius: 25px;
   margin-bottom: 20px;
 
+
+
   @media (max-width: 750px) {
     width: 170px;
   }
 `;
+
 
 const StyledImageContainer = styled.div`
   width: 300px;
@@ -48,6 +53,11 @@ const StyledImageContainer = styled.div`
   position: relative;
   box-shadow: 0 0px 15px rgba(0, 0, 0, 0.3);
   border-radius: 20px;
+
+  &:hover {
+    box-shadow: 0px 5px 40px -10px var(--white-dark);
+    transition: all 0.45s ease 0s;
+  }
 
   @media (max-width: 750px) {
     width: 170px;
@@ -59,6 +69,13 @@ const StyledImage = styled(Image)`
   height: auto;
   text-align: center;
   object-fit: cover;
+`;
+
+const StyledCardTitleContainer = styled.div`
+&:hover {
+    color: var(--green-light-dark);
+    transition: all 0.45s ease 0s;
+  }
 `;
 
 const StyledH2 = styled.h2`

--- a/components/PlantCard/index.js
+++ b/components/PlantCard/index.js
@@ -21,8 +21,7 @@ export default function PlantCard({
           isOwned={isOwned}
         />
         <StyledImage src={image} alt={name} fill={true} />
-      </StyledImageContainer>
-      
+      </StyledImageContainer>    
         <StyledH2>{name}</StyledH2>
         <StyledH3>{botanicalName}</StyledH3>
       </Link>

--- a/components/PlantCard/index.js
+++ b/components/PlantCard/index.js
@@ -11,13 +11,19 @@ export default function PlantCard({
   handleToggleOwned,
   isOwned,
 }) {
+
+  function handleToggleOwnedButtonClick (event) {
+    event.preventDefault();
+    handleToggleOwned(plantId);
+  }
+
   return (
     <StyledCard>
       <Link href={`/plants/${plantId}`}>
       <StyledImageContainer>
         <PlantOwnedButton
           plantId={plantId}
-          onClick={(event) => {event.preventDefault(); handleToggleOwned(plantId)}}
+          onClick={handleToggleOwnedButtonClick}
           isOwned={isOwned}
         />
         <StyledImage src={image} alt={name} fill={true} />

--- a/components/PlantCard/index.js
+++ b/components/PlantCard/index.js
@@ -13,15 +13,16 @@ export default function PlantCard({
 }) {
   return (
     <StyledCard>
+      <Link href={`/plants/${plantId}`}>
       <StyledImageContainer>
         <PlantOwnedButton
           plantId={plantId}
-          onClick={() => handleToggleOwned(plantId)}
+          onClick={(event) => {event.preventDefault(); handleToggleOwned(plantId)}}
           isOwned={isOwned}
         />
         <StyledImage src={image} alt={name} fill={true} />
       </StyledImageContainer>
-      <Link href={`/plants/${plantId}`}>
+      
         <StyledH2>{name}</StyledH2>
         <StyledH3>{botanicalName}</StyledH3>
       </Link>


### PR DESCRIPTION
https://github.com/users/StephMode/projects/5?pane=issue&itemId=86321288&issue=StephMode%7Cplant-pal%7C18 US clickable plant card

This PR is part of the work to improve the PlantCard component that displays single "plants" on the Home Page and My Plants page. To achieve this we:

- changed the `PlantCard` so that the image of the plant, the plant name and the botanical name are clickable as a link to a plant details page.
- adapted the props on the `PlantOwnedButton` so that clicking this button only toggles `isOwned` but not to link on the plant details page.
- improved the styling by implementing hover effects on image as well as plant name and the botanical name to improve UX.

