### PR TITLE
Stephan feature 13 cross referencing

### DIFF
--- a/components/Button/index.js
+++ b/components/Button/index.js
@@ -1,17 +1,19 @@
-import styled from "styled-components";
+import styled, { ThemeProvider } from "styled-components";
 
-export default function Button({ buttonText, handleButtonFunction }) {
+export default function Button({ buttonText, handleButtonFunction, buttonRole }) {
 
     return (
+        <ThemeProvider theme={buttonRole === "deleteButton" ? deleteButtonTheme : mainTheme}>
         <StyledButton type="button" onClick={handleButtonFunction}>
             {buttonText}
         </StyledButton>
+        </ThemeProvider>
     )
 }
 
 
 const StyledButton = styled.button`
-    background-color: var(--brown);
+    background-color: ${props => props.theme.main};
     padding: 8px 20px 1px 20px;
     border: none;
     border-radius: 20px;
@@ -21,7 +23,20 @@ const StyledButton = styled.button`
     transition: 0.5s ease-in-out;
 
     &:hover {
-    background-color: var(--brown-dark);
+    background-color: ${props => props.theme.hover};
   }
 `;
-
+StyledButton.defaultProps = {
+    theme: {
+        main: "var(--brown)",
+        hover: "var(--brown-dark)"
+    }
+}
+const deleteButtonTheme = {
+    main: "var(--gray)",
+    hover: "var(--gray-dark)"
+}
+const mainTheme = {
+    main: "var(--brown)",
+    hover: "var(--brown-dark)"
+}

--- a/components/PlantDetails/index.js
+++ b/components/PlantDetails/index.js
@@ -5,6 +5,7 @@ import Button from "../Button";
 import Modal from "../Modal";
 import PlantDeleteSection from "../PlantDeleteSection";
 import Form from "../Form";
+import PlantOwnedButton from "../PlantOwnedButton";
 import { RiDropLine } from "react-icons/ri";
 import { FaChevronLeft } from "react-icons/fa6";
 import { RiDropFill } from "react-icons/ri";
@@ -26,7 +27,9 @@ export default function PlantDetails({
   handleEditPlant, 
   handleAddPlant, 
   onDeletePlant, 
-  tipsToBeTagged }) {
+  tipsToBeTagged,
+  handleToggleOwned,
+  }) {
   const router = useRouter();
 
 
@@ -37,6 +40,13 @@ export default function PlantDetails({
     <>
       <StyledImageContainer>
             <StyledImage src={plant.imageUrl} alt={plant.name} fill />
+            <StyledPlantOwnedButtonWrapper>
+              <PlantOwnedButton 
+                isOwned={plant.isOwned}
+                plantId={plant.id}
+                onClick={() => handleToggleOwned(plant.id)}
+              />
+            </StyledPlantOwnedButtonWrapper>
       </StyledImageContainer>
       
       <StyledPlantContainer>
@@ -130,6 +140,7 @@ export default function PlantDetails({
         <StyledIconContainer onClick={() => router.back()} type="button">
           <FaChevronLeft/>
         </StyledIconContainer>
+        
     </>
   );
 }
@@ -173,6 +184,11 @@ const StyledImage = styled(Image)`
   height: auto;
   text-align: center;
   object-fit: cover;
+`;
+const StyledPlantOwnedButtonWrapper = styled.div`
+  position: relative;
+  top: 45px;
+  right: 20px;
 `;
 const StyledIconContainer = styled.button `
     background-color: var(--green-light);

--- a/components/PlantDetails/index.js
+++ b/components/PlantDetails/index.js
@@ -29,10 +29,10 @@ export default function PlantDetails({
   tipsToBeTagged }) {
   const router = useRouter();
 
-  
+
   const realtedTips = tipsToBeTagged.filter((tip) => tip.relatedPlants.includes(plant.id));
 
-  
+
   return (
     <>
       <StyledImageContainer>

--- a/components/PlantDetails/index.js
+++ b/components/PlantDetails/index.js
@@ -33,7 +33,7 @@ export default function PlantDetails({
   const router = useRouter();
 
 
-  const realtedTips = tipsToBeTagged.filter((tip) => tip.relatedPlants.includes(plant.id));
+  const relatedTips = tipsToBeTagged.filter((tip) => tip.relatedPlants.includes(plant.id));
 
 
   return (
@@ -108,7 +108,7 @@ export default function PlantDetails({
         <StyledTipH3>Related Care Tips:</StyledTipH3>
 
           <StyledTagContainer>
-              {realtedTips.map((tip) => plant === undefined ? null : (
+              {relatedTips.map((tip) => plant === undefined ? null : (
                 <li key={tip.id}>
                   <Tag
                     tagId={tip.id}

--- a/components/PlantDetails/index.js
+++ b/components/PlantDetails/index.js
@@ -99,8 +99,9 @@ export default function PlantDetails({
             </StyledFertilizerUl>
           </StyledIconSection>
         </StyledPlantNeedsContainer>
-        <section>
-          <ul>
+        <StyledTipH3>Related Care Tips:</StyledTipH3>
+
+          <StyledTagContainer>
               {realtedTips.map((tip) => plant === undefined ? null : (
                 <li key={tip.id}>
                   <Tag
@@ -113,8 +114,8 @@ export default function PlantDetails({
                 </li>
               ))}
             
-          </ul>
-        </section>
+          </StyledTagContainer>
+
         <StyledEditDeleteSection>
           <Button buttonText={<FaTrashAlt />} handleButtonFunction={() => handleToggleModal("Delete")}/>
       </StyledEditDeleteSection>
@@ -149,12 +150,17 @@ const StyledPlantContainer = styled.section`
     width: 70%;
   }
 `;
-
 const StyledPlantNeedsContainer = styled.article`
   display: flex;
   flex-direction: column;
 `;
-
+const StyledTipH3 = styled.h3`
+  margin: 20px 0px;
+  text-align: left;
+  color: var(--green-main);
+  font-weight: bold;
+  font-size: 20px;
+`;
 const StyledImageContainer = styled.div`
   width: 100%;
   height: 300px;
@@ -168,7 +174,6 @@ const StyledImageContainer = styled.div`
     height: 500px;
   }
 `;
-
 const StyledImage = styled(Image)`
   width: 200%;
   height: auto;
@@ -194,7 +199,6 @@ const StyledIconSection = styled.section`
   display: flex;
   align-items: center;
   color: var(--green-main);
-  font-weight: bold;
   font-size: 20px;
   gap: 10px;
   margin-bottom: 5px;
@@ -231,6 +235,12 @@ const StyledIconSection = styled.section`
   font-size: 14px;
   font-weight: normal;
 `;
+
+const StyledTagContainer = styled.ul`
+  display: flex;
+  justify-content:flex-start;
+`;
+
 const StyledEditDeleteSection = styled.section`
   display: flex;
   width: 100%;

--- a/components/PlantDetails/index.js
+++ b/components/PlantDetails/index.js
@@ -92,6 +92,9 @@ export default function PlantDetails({
             </StyledFertilizerUl>
           </StyledIconSection>
         </StyledPlantNeedsContainer>
+        <StyledEditDeleteSection>
+          <Button buttonText={<FaTrashAlt />} handleButtonFunction={() => handleToggleModal("Delete")}/>
+        </StyledEditDeleteSection>
         <StyledTipH3>Related Care Tips:</StyledTipH3>
 
           <StyledTagContainer>
@@ -109,9 +112,7 @@ export default function PlantDetails({
             
           </StyledTagContainer>
 
-        <StyledEditDeleteSection>
-          <Button buttonText={<FaTrashAlt />} handleButtonFunction={() => handleToggleModal("Delete")}/>
-      </StyledEditDeleteSection>
+        
       </StyledPlantContainer>
 
         {showModal &&
@@ -238,4 +239,5 @@ const StyledEditDeleteSection = styled.section`
   display: flex;
   width: 100%;
   margin-top: 25px;
+  filter: grayscale(100%);
 `;

--- a/components/PlantDetails/index.js
+++ b/components/PlantDetails/index.js
@@ -108,7 +108,7 @@ export default function PlantDetails({
         <StyledTipH3>Related Care Tips:</StyledTipH3>
 
           <StyledTagContainer>
-              {relatedTips.map((tip) => plant === undefined ? null : (
+              {relatedTips.map((tip) => (
                 <li key={tip.id}>
                   <Tag
                     tagId={tip.id}
@@ -160,7 +160,7 @@ const StyledPlantNeedsContainer = styled.article`
   flex-direction: column;
 `;
 const StyledTipH3 = styled.h3`
-  margin: 20px 0px;
+  margin: 20px 0;
   text-align: left;
   color: var(--green-main);
   font-weight: bold;
@@ -172,7 +172,7 @@ const StyledImageContainer = styled.div`
   overflow: hidden;
   position: relative;
   border-radius: 35px;
-  box-shadow: 0 0px 51px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 0 51px rgba(0, 0, 0, 0.3);
 
   
   @media (min-width: 750px) {
@@ -235,7 +235,6 @@ const StyledIconSection = styled.section`
  const StyledFertilizerUl = styled.ul`
   gap: 5px;
   margin : 0 0 0 30px;
-  justify-content: flex-start;
  `;
  const StyledFertilizerLi = styled.li`
   color: var(--white);

--- a/components/PlantDetails/index.js
+++ b/components/PlantDetails/index.js
@@ -15,8 +15,13 @@ import { IoMdMoon } from "react-icons/io";
 import { GiPowder } from "react-icons/gi";
 import { FaTrashAlt } from "react-icons/fa";
 import { FaPen } from "react-icons/fa6";
+import { useRouter } from "next/router";
 
 export default function PlantDetails({ plant, handleToggleModal, isDelete, isEdit, showModal, handleEditPlant, handleAddPlant, onDeletePlant }) {
+  const router = useRouter();
+
+
+  
   return (
     <>
       <StyledImageContainer>
@@ -76,6 +81,11 @@ export default function PlantDetails({ plant, handleToggleModal, isDelete, isEdi
             </StyledFertilizerUl>
           </StyledIconSection>
         </StyledPlantNeedsContainer>
+        <section>
+          <ul>
+            <li>lala</li>
+          </ul>
+        </section>
         <StyledEditDeleteSection>
           <Button buttonText={<FaTrashAlt />} handleButtonFunction={() => handleToggleModal("Delete")}/>
       </StyledEditDeleteSection>
@@ -93,11 +103,9 @@ export default function PlantDetails({ plant, handleToggleModal, isDelete, isEdi
                 "This is an error, please reload page."
           } />}
 
-        <Link href="/">
-        <StyledIconContainer>
-          <FaChevronLeft />
+        <StyledIconContainer onClick={() => router.back()} type="button">
+          <FaChevronLeft/>
         </StyledIconContainer>
-        </Link>
     </>
   );
 }
@@ -138,9 +146,10 @@ const StyledImage = styled(Image)`
   text-align: center;
   object-fit: cover;
 `;
-const StyledIconContainer = styled.span `
+const StyledIconContainer = styled.button `
     background-color: var(--green-light);
     border-radius: 40px;
+    border: none;
     width: 50px;
     height: 50px;
     display: flex;

--- a/components/PlantDetails/index.js
+++ b/components/PlantDetails/index.js
@@ -30,16 +30,9 @@ export default function PlantDetails({
   const router = useRouter();
 
   
-
-  // const relatedPlants = tipsToBeTagged.map((tip) => tip.relatedPlants.map((relatedPlant) => relatedPlant));
-  // const searchableTips = tipsToBeTagged.forEach((element) => element.find(plant.id))
-  // console.log(searchableTips);
-  // const relatedTips = relatedPlants.forEach((element) => element.find(plant))
-  
   const realtedTips = tipsToBeTagged.filter((tip) => tip.relatedPlants.includes(plant.id));
 
   
-
   return (
     <>
       <StyledImageContainer>

--- a/components/PlantDetails/index.js
+++ b/components/PlantDetails/index.js
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import styled from "styled-components";
-import Link from "next/link";
+import Tag from "../Tag";
 import Button from "../Button";
 import Modal from "../Modal";
 import PlantDeleteSection from "../PlantDeleteSection";
@@ -17,11 +17,29 @@ import { FaTrashAlt } from "react-icons/fa";
 import { FaPen } from "react-icons/fa6";
 import { useRouter } from "next/router";
 
-export default function PlantDetails({ plant, handleToggleModal, isDelete, isEdit, showModal, handleEditPlant, handleAddPlant, onDeletePlant }) {
+export default function PlantDetails({ 
+  plant, 
+  handleToggleModal, 
+  isDelete, 
+  isEdit, 
+  showModal, 
+  handleEditPlant, 
+  handleAddPlant, 
+  onDeletePlant, 
+  tipsToBeTagged }) {
   const router = useRouter();
 
+  
+
+  // const relatedPlants = tipsToBeTagged.map((tip) => tip.relatedPlants.map((relatedPlant) => relatedPlant));
+  // const searchableTips = tipsToBeTagged.forEach((element) => element.find(plant.id))
+  // console.log(searchableTips);
+  // const relatedTips = relatedPlants.forEach((element) => element.find(plant))
+  
+  const realtedTips = tipsToBeTagged.filter((tip) => tip.relatedPlants.includes(plant.id));
 
   
+
   return (
     <>
       <StyledImageContainer>
@@ -83,7 +101,18 @@ export default function PlantDetails({ plant, handleToggleModal, isDelete, isEdi
         </StyledPlantNeedsContainer>
         <section>
           <ul>
-            <li>lala</li>
+              {realtedTips.map((tip) => plant === undefined ? null : (
+                <li key={tip.id}>
+                  <Tag
+                    tagId={tip.id}
+                    tagType={"tips"}
+                    headline={tip.title}
+                    subHeadline={tip.shortBodyContent}
+                    image={tip.imageURL}
+                  />
+                </li>
+              ))}
+            
           </ul>
         </section>
         <StyledEditDeleteSection>

--- a/components/PlantDetails/index.js
+++ b/components/PlantDetails/index.js
@@ -103,7 +103,7 @@ export default function PlantDetails({
           </StyledIconSection>
         </StyledPlantNeedsContainer>
         <StyledEditDeleteSection>
-          <Button buttonText={<FaTrashAlt />} handleButtonFunction={() => handleToggleModal("Delete")}/>
+          <Button buttonText={<FaTrashAlt />} handleButtonFunction={() => handleToggleModal("Delete")} buttonRole={"deleteButton"}/>
         </StyledEditDeleteSection>
         <StyledTipH3>Related Care Tips:</StyledTipH3>
 
@@ -255,5 +255,4 @@ const StyledEditDeleteSection = styled.section`
   display: flex;
   width: 100%;
   margin-top: 25px;
-  filter: grayscale(100%);
 `;

--- a/components/Tag/index.js
+++ b/components/Tag/index.js
@@ -11,7 +11,7 @@ export default function Tag({tagId, headline, subHeadline, image, tagType }) {
        
        <StyledImage src={image} width={55} height={55} alt={`"image of ${headline}"`}/>
         <div>
-          <StyledH4>{headline}</StyledH4>
+          <h4>{headline}</h4>
           <StyledH5>{subHeadline}</StyledH5>
         </div>
         </StyledTag>
@@ -58,10 +58,6 @@ const StyledImage = styled(Image)`
   border-radius: 50px;
   min-width: 55px;
   min-height: 55px;
-`;
-
-
-const StyledH4 = styled.h4`
 `;
 
 const StyledH5 = styled.h5`

--- a/components/Tag/index.js
+++ b/components/Tag/index.js
@@ -8,7 +8,7 @@ export default function Tag({tagId, headline, subHeadline, image, tagType }) {
       <Link href={`/${tagType}/${tagId}`}>
         <StyledTag>
        
-       <StyledImage src={image} width={50} height={50} alt={`"image of ${headline}"`}/>
+       <StyledImage src={image} width={55} height={55} alt={`"image of ${headline}"`}/>
         <div>
           <StyledH4>{headline}</StyledH4>
           <StyledH5>{subHeadline}</StyledH5>
@@ -22,11 +22,13 @@ export default function Tag({tagId, headline, subHeadline, image, tagType }) {
 
 const StyledTag = styled.article`
   min-width: 200px;
+  max-width: 300px;
   display: flex;
+  align-items: center;
   gap: 15px;
   border-radius: 40px;
   background-color: var(--green-light);
-  padding: 7px 18px 7px 7px;
+  padding: 10px 25px 10px 10px;
   transition: all ease-in-out 0.5s;
 
   &:hover{
@@ -37,6 +39,8 @@ const StyledTag = styled.article`
 
 const StyledImage = styled(Image)`
   border-radius: 50px;
+  min-width: 55px;
+  min-height: 55px;
 `;
 
 

--- a/components/Tag/index.js
+++ b/components/Tag/index.js
@@ -9,7 +9,7 @@ export default function Tag({tagId, headline, subHeadline, image, tagType }) {
         <ThemeProvider theme={tagType === "plants" ? plantTagtheme : tipTagtheme}>
         <StyledTag>
        
-       <StyledImage src={image} width={55} height={55} alt={`"image of ${headline}"`}/>
+       <StyledImage src={image} width={55} height={55} alt={`image of ${headline}`}/>
         <div>
           <h4>{headline}</h4>
           <StyledH5>{subHeadline}</StyledH5>

--- a/components/Tag/index.js
+++ b/components/Tag/index.js
@@ -3,8 +3,6 @@ import Image from "next/image";
 import styled from "styled-components";
 
 export default function Tag({tagId, headline, subHeadline, image, tagType }) {
-    // wir können die compo so bauen: prop hashtagType gibt vor, welche Art von hashtag und dementsprechend conditional render
-    // TipDetails und PlantDetails geben dann jweils die detail props für den Einzelhashtag runter
   
     return (
       <Link href={`/${tagType}/${tagId}`}>

--- a/components/Tag/index.js
+++ b/components/Tag/index.js
@@ -1,15 +1,17 @@
 import Link from "next/link";
+import Image from "next/image";
 
-export default function Tag({id, headline, subheadline }) {
+export default function Tag({id, headline, subHeadline, image, tagType }) {
     // wir können die compo so bauen: prop hashtagType gibt vor, welche Art von hashtag und dementsprechend conditional render
     // TipDetails und PlantDetails geben dann jweils die detail props für den Einzelhashtag runter
   
     return (
       <article>
-       {/* <Link href={`/plants/${plantID}`}>
-          <h3>{name}</h3>
-          <h3>{botanicalName}</h3>
-        </Link> */}
+       <Link href={`/${tagType}/${id}`}>
+        <h3>{headline}</h3>
+        <h4>{subHeadline}</h4>
+        <Image src={image} width={50} height={50}/>
+       </Link>
       </article>
   )
 }

--- a/components/Tag/index.js
+++ b/components/Tag/index.js
@@ -2,12 +2,12 @@ import Link from "next/link";
 import Image from "next/image";
 import styled from "styled-components";
 
-export default function Tag({id, headline, subHeadline, image, tagType }) {
+export default function Tag({tagId, headline, subHeadline, image, tagType }) {
     // wir können die compo so bauen: prop hashtagType gibt vor, welche Art von hashtag und dementsprechend conditional render
     // TipDetails und PlantDetails geben dann jweils die detail props für den Einzelhashtag runter
   
     return (
-      <Link href={`/${tagType}/${id}`}>
+      <Link href={`/${tagType}/${tagId}`}>
         <StyledTag>
        
        <StyledImage src={image} width={50} height={50} alt={`"image of ${headline}"`}/>

--- a/components/Tag/index.js
+++ b/components/Tag/index.js
@@ -8,9 +8,9 @@ export default function Tag({id, headline, subHeadline, image, tagType }) {
     return (
       <article>
        <Link href={`/${tagType}/${id}`}>
-        <h3>{headline}</h3>
-        <h4>{subHeadline}</h4>
-        <Image src={image} width={50} height={50}/>
+       <Image src={image} width={50} height={50} alt={`"image of ${headline}"`}/>
+        <h4>{headline}</h4>
+        <h5>{subHeadline}</h5>
        </Link>
       </article>
   )

--- a/components/Tag/index.js
+++ b/components/Tag/index.js
@@ -1,11 +1,12 @@
 import Link from "next/link";
 import Image from "next/image";
-import styled from "styled-components";
+import styled, { ThemeProvider } from "styled-components";
 
 export default function Tag({tagId, headline, subHeadline, image, tagType }) {
   
     return (
       <Link href={`/${tagType}/${tagId}`}>
+        <ThemeProvider theme={tagType === "plants" ? plantTagtheme : tipTagtheme}>
         <StyledTag>
        
        <StyledImage src={image} width={55} height={55} alt={`"image of ${headline}"`}/>
@@ -14,6 +15,7 @@ export default function Tag({tagId, headline, subHeadline, image, tagType }) {
           <StyledH5>{subHeadline}</StyledH5>
         </div>
         </StyledTag>
+        </ThemeProvider>
       </Link>
   )
 }
@@ -27,15 +29,30 @@ const StyledTag = styled.article`
   align-items: center;
   gap: 15px;
   border-radius: 40px;
-  background-color: var(--green-light);
+  background-color: ${props => props.theme.main};
   padding: 10px 25px 10px 10px;
   transition: all ease-in-out 0.5s;
+  color: var(--black);
 
   &:hover{
-    background-color: var(--green-main);
+    background-color: ${props => props.theme.hover};
     color: var(--white)
   }
 `;
+StyledTag.defaultProps = {
+  theme: {
+    main: "var(--green-light)",
+    hover: "var(--green-main)"
+  }
+}
+const tipTagtheme = {
+  main: "var(--brown)",
+  hover: "var(--brown-dark)"
+}
+const plantTagtheme = {
+  main: "var(--green-light)",
+  hover: "var(--green-main)"
+}
 
 const StyledImage = styled(Image)`
   border-radius: 50px;
@@ -48,7 +65,5 @@ const StyledH4 = styled.h4`
 `;
 
 const StyledH5 = styled.h5`
-  color: var(--gray);
   font-weight: normal;
-  
 `;

--- a/components/Tag/index.js
+++ b/components/Tag/index.js
@@ -1,19 +1,52 @@
 import Link from "next/link";
 import Image from "next/image";
+import styled from "styled-components";
 
 export default function Tag({id, headline, subHeadline, image, tagType }) {
     // wir können die compo so bauen: prop hashtagType gibt vor, welche Art von hashtag und dementsprechend conditional render
     // TipDetails und PlantDetails geben dann jweils die detail props für den Einzelhashtag runter
   
     return (
-      <article>
-       <Link href={`/${tagType}/${id}`}>
-       <Image src={image} width={50} height={50} alt={`"image of ${headline}"`}/>
-        <h4>{headline}</h4>
-        <h5>{subHeadline}</h5>
-       </Link>
-      </article>
+      <Link href={`/${tagType}/${id}`}>
+        <StyledTag>
+       
+       <StyledImage src={image} width={50} height={50} alt={`"image of ${headline}"`}/>
+        <div>
+        <StyledH4>{headline}</StyledH4>
+        <StyledH5>{subHeadline}</StyledH5>
+        </div>
+        </StyledTag>
+      </Link>
   )
 }
 
- 
+
+
+const StyledTag = styled.article`
+  min-width: 200px;
+  display: flex;
+  gap: 15px;
+  border-radius: 40px;
+  background-color: var(--green-light);
+  padding: 10px 25px 10px 10px;
+  transition: all ease-in-out 0.5s;
+
+  &:hover{
+    background-color: var(--green-main);
+    color: var(--white)
+  }
+`;
+
+const StyledImage = styled(Image)`
+  border-radius: 50px;
+`;
+
+
+const StyledH4 = styled.h4`
+`;
+
+const StyledH5 = styled.h5`
+  color: var(--gray);
+  font-weight: normal;
+  
+`;

--- a/components/Tag/index.js
+++ b/components/Tag/index.js
@@ -12,8 +12,8 @@ export default function Tag({id, headline, subHeadline, image, tagType }) {
        
        <StyledImage src={image} width={50} height={50} alt={`"image of ${headline}"`}/>
         <div>
-        <StyledH4>{headline}</StyledH4>
-        <StyledH5>{subHeadline}</StyledH5>
+          <StyledH4>{headline}</StyledH4>
+          <StyledH5>{subHeadline}</StyledH5>
         </div>
         </StyledTag>
       </Link>
@@ -28,7 +28,7 @@ const StyledTag = styled.article`
   gap: 15px;
   border-radius: 40px;
   background-color: var(--green-light);
-  padding: 10px 25px 10px 10px;
+  padding: 7px 18px 7px 7px;
   transition: all ease-in-out 0.5s;
 
   &:hover{

--- a/components/Tag/index.js
+++ b/components/Tag/index.js
@@ -1,0 +1,17 @@
+import Link from "next/link";
+
+export default function Tag({id, headline, subheadline }) {
+    // wir können die compo so bauen: prop hashtagType gibt vor, welche Art von hashtag und dementsprechend conditional render
+    // TipDetails und PlantDetails geben dann jweils die detail props für den Einzelhashtag runter
+  
+    return (
+      <article>
+       {/* <Link href={`/plants/${plantID}`}>
+          <h3>{name}</h3>
+          <h3>{botanicalName}</h3>
+        </Link> */}
+      </article>
+  )
+}
+
+ 

--- a/components/TipDetails/index.js
+++ b/components/TipDetails/index.js
@@ -20,17 +20,16 @@ export default function TipDetails({ tip }) {
             <StyledImage src={tip.imageURL} alt={tip.title} fill />
       </StyledImageContainer>
       
+      <StyledIconContainer onClick={() =>  router.back()} type="button">
+          <FaChevronLeft />
+        </StyledIconContainer>
+
       <StyledTipContainer>
         <StyledH2>{tip.title}</StyledH2>
         <StyledDescription>{tip.bodyContent}</StyledDescription>
-      </StyledTipContainer>
-
-     
-        <StyledIconContainer onClick={() =>  router.back()} type="button">
-          <FaChevronLeft />
-        </StyledIconContainer>
-        <h3>Related Plants</h3>
-        <ul>
+      
+        <StyledH3>Related Plants</StyledH3>
+        <StyledTagContainer>
           {relatedPlantObject.map((plant) => (
             <li key={plant.id}>
               <Tag
@@ -43,7 +42,13 @@ export default function TipDetails({ tip }) {
             </li>
           ))}
           
-        </ul>
+        </StyledTagContainer>
+      
+      </StyledTipContainer>
+
+     
+        
+        
         
 
         
@@ -102,10 +107,19 @@ const StyledIconContainer = styled.button `
 
  const StyledH2 = styled.h2`
   margin-bottom: 13px;
-  max-width: 260px;
  `;
 
  const StyledDescription = styled.p`
-  margin-bottom: 20px;
+  margin-bottom: 30px;
   text-align: justify;
  `;
+
+const StyledH3 = styled.h3`
+ margin-bottom: 20px;
+ text-align: left;
+`;
+
+const StyledTagContainer = styled.ul`
+  display: flex;
+  justify-content:flex-start;
+`;

--- a/components/TipDetails/index.js
+++ b/components/TipDetails/index.js
@@ -54,13 +54,7 @@ export default function TipDetails({ tip, plantsToBeTagged }) {
         </StyledTagContainer>
       
       </StyledTipContainer>
-
-     
-        
-        
-        
-
-        
+       
     </>
   );
 }

--- a/components/TipDetails/index.js
+++ b/components/TipDetails/index.js
@@ -1,18 +1,19 @@
 import Image from "next/image";
 import styled from "styled-components";
-import Link from "next/link";
 import { FaChevronLeft } from "react-icons/fa6";
 import { useRouter } from "next/router";
-import { plants as initialPlants } from "/lib/plantData";
 import Tag from "../Tag";
 
 
-export default function TipDetails({ tip }) {
+export default function TipDetails({ tip, plantsToBeTagged }) {
   const router = useRouter();
 
   const relatedPlants = tip.relatedPlants.map((relatedPlant) => relatedPlant);
-  const relatedPlantObject = relatedPlants.map((plantID) => initialPlants.find((plant) => plant.id === plantID));
-
+  const relatedPlantObject = relatedPlants.map((plantID) => plantsToBeTagged.find((plant) => plant.id === plantID));
+  // console.log(relatedPlantObject);
+  // console.log(relatedPlantObject.includes(undefined));
+  
+  
 
   return (
     <>
@@ -30,17 +31,19 @@ export default function TipDetails({ tip }) {
       
         <StyledH3>Related Plants</StyledH3>
         <StyledTagContainer>
-          {relatedPlantObject.map((plant) => (
-            <li key={plant.id}>
+          {relatedPlantObject.map((plant) => 
+            plant === undefined ? null :
+            (<li key={plant.id}>
               <Tag
-                id={plant.id}
+                tagId={plant.id}
                 tagType={"plants"}
                 headline={plant.name}
                 subHeadline={plant.botanicalName}
                 image={plant.imageUrl}
               />              
             </li>
-          ))}
+            )
+          )}
           
         </StyledTagContainer>
       

--- a/components/TipDetails/index.js
+++ b/components/TipDetails/index.js
@@ -3,17 +3,27 @@ import styled from "styled-components";
 import { FaChevronLeft } from "react-icons/fa6";
 import { useRouter } from "next/router";
 import Tag from "../Tag";
+import { useState } from "react";
 
 
 export default function TipDetails({ tip, plantsToBeTagged }) {
   const router = useRouter();
+
+  const [undefinedChecker, SetUndefinedChecker] = useState(false);  
 
   const relatedPlants = tip.relatedPlants.map((relatedPlant) => relatedPlant);
   const relatedPlantObject = relatedPlants.map((plantID) => plantsToBeTagged.find((plant) => plant.id === plantID));
   // console.log(relatedPlantObject);
   // console.log(relatedPlantObject.includes(undefined));
   
+  const undefinedCount = relatedPlantObject.filter(plant => plant === undefined).length;
+  // console.log(undefinedCount);
   
+  const noRelatedPlants = () => {if (undefinedCount === relatedPlantObject.length) {
+    SetUndefinedChecker(true)
+  }}
+
+  // console.log(undefinedChecker);
 
   return (
     <>
@@ -29,7 +39,7 @@ export default function TipDetails({ tip, plantsToBeTagged }) {
         <StyledH2>{tip.title}</StyledH2>
         <StyledDescription>{tip.bodyContent}</StyledDescription>
       
-        <StyledH3>Related Plants</StyledH3>
+        {undefinedChecker ? (<StyledH3>Related Plants</StyledH3>) : ("")}
         <StyledTagContainer>
           {relatedPlantObject.map((plant) => 
             plant === undefined ? null :

--- a/components/TipDetails/index.js
+++ b/components/TipDetails/index.js
@@ -4,13 +4,14 @@ import Link from "next/link";
 import { FaChevronLeft } from "react-icons/fa6";
 import { useRouter } from "next/router";
 import { plants as initialPlants } from "/lib/plantData";
+import Tag from "../Tag";
 
 
 export default function TipDetails({ tip }) {
   const router = useRouter();
 
   const relatedPlants = tip.relatedPlants.map((relatedPlant) => relatedPlant);
-  const relatedPlantObject = relatedPlants.map((plantID) => initialPlants.find((plant) => plant.id === plantID))
+  const relatedPlantObject = relatedPlants.map((plantID) => initialPlants.find((plant) => plant.id === plantID));
 
 
   return (
@@ -39,6 +40,13 @@ export default function TipDetails({ tip }) {
           ))}
           
         </ul>
+        
+
+        <Tag
+          plantID={1}
+          name={"Piranha Plant"}
+          botanicalName={"Prinanha Plantus"}
+        />
     </>
   );
 }

--- a/components/TipDetails/index.js
+++ b/components/TipDetails/index.js
@@ -32,21 +32,21 @@ export default function TipDetails({ tip }) {
         <h3>Related Plants</h3>
         <ul>
           {relatedPlantObject.map((plant) => (
-            <li>
-              <h3>{plant.name}</h3>
-              <h3>{plant.botanicalName}</h3>
-              
+            <li key={plant.id}>
+              <Tag
+                id={plant.id}
+                tagType={"plants"}
+                headline={plant.name}
+                subHeadline={plant.botanicalName}
+                image={plant.imageUrl}
+              />              
             </li>
           ))}
           
         </ul>
         
 
-        <Tag
-          plantID={1}
-          name={"Piranha Plant"}
-          botanicalName={"Prinanha Plantus"}
-        />
+        
     </>
   );
 }

--- a/components/TipDetails/index.js
+++ b/components/TipDetails/index.js
@@ -9,21 +9,17 @@ import { useState } from "react";
 export default function TipDetails({ tip, plantsToBeTagged }) {
   const router = useRouter();
 
-  const [undefinedChecker, SetUndefinedChecker] = useState(false);  
+  const [noRelatedPlants, setNoRelatedPlants] = useState(false);  
 
   const relatedPlants = tip.relatedPlants.map((relatedPlant) => relatedPlant);
   const relatedPlantObject = relatedPlants.map((plantID) => plantsToBeTagged.find((plant) => plant.id === plantID));
-  // console.log(relatedPlantObject);
-  // console.log(relatedPlantObject.includes(undefined));
   
   const undefinedCount = relatedPlantObject.filter(plant => plant === undefined).length;
-  // console.log(undefinedCount);
   
-  const noRelatedPlants = () => {if (undefinedCount === relatedPlantObject.length) {
-    SetUndefinedChecker(true)
+  const noRelatedPlantsChecker = () => {if (undefinedCount === relatedPlantObject.length) {
+    setNoRelatedPlants(true)
   }}
 
-  // console.log(undefinedChecker);
 
   return (
     <>
@@ -39,7 +35,7 @@ export default function TipDetails({ tip, plantsToBeTagged }) {
         <StyledH2>{tip.title}</StyledH2>
         <StyledDescription>{tip.bodyContent}</StyledDescription>
       
-        {undefinedChecker ? (<StyledH3>Related Plants</StyledH3>) : ("")}
+        {!noRelatedPlants ? (<StyledH3>Related Plants</StyledH3>) : ("")}
         <StyledTagContainer>
           {relatedPlantObject.map((plant) => 
             plant === undefined ? null :

--- a/components/TipDetails/index.js
+++ b/components/TipDetails/index.js
@@ -35,7 +35,7 @@ export default function TipDetails({ tip, plantsToBeTagged }) {
         <StyledH2>{tip.title}</StyledH2>
         <StyledDescription>{tip.bodyContent}</StyledDescription>
       
-        {!noRelatedPlants ? (<StyledH3>Related Plants</StyledH3>) : ("")}
+        {noRelatedPlants && <StyledH3>Related Plants</StyledH3>}
         <StyledTagContainer>
           {relatedPlantObject.map((plant) => 
             plant === undefined ? null :

--- a/components/TipDetails/index.js
+++ b/components/TipDetails/index.js
@@ -3,10 +3,15 @@ import styled from "styled-components";
 import Link from "next/link";
 import { FaChevronLeft } from "react-icons/fa6";
 import { useRouter } from "next/router";
+import { plants as initialPlants } from "/lib/plantData";
 
 
 export default function TipDetails({ tip }) {
   const router = useRouter();
+
+  const relatedPlants = tip.relatedPlants.map((relatedPlant) => relatedPlant);
+  const relatedPlantObject = relatedPlants.map((plantID) => initialPlants.find((plant) => plant.id === plantID))
+
 
   return (
     <>
@@ -23,6 +28,17 @@ export default function TipDetails({ tip }) {
         <StyledIconContainer onClick={() =>  router.back()} type="button">
           <FaChevronLeft />
         </StyledIconContainer>
+        <h3>Related Plants</h3>
+        <ul>
+          {relatedPlantObject.map((plant) => (
+            <li>
+              <h3>{plant.name}</h3>
+              <h3>{plant.botanicalName}</h3>
+              
+            </li>
+          ))}
+          
+        </ul>
     </>
   );
 }

--- a/pages/plants/[id].js
+++ b/pages/plants/[id].js
@@ -1,8 +1,10 @@
 import { useRouter } from "next/router";
 import PlantDetails from "/components/PlantDetails/";
 
-export default function PlantDetailsPage({ plants, onDeletePlant, handleEditPlant, handleAddPlant, handleToggleModal, showModal, isEdit, isDelete }) {
+export default function PlantDetailsPage({ plants, onDeletePlant, handleEditPlant, handleAddPlant, handleToggleModal, showModal, isEdit, isDelete, tips }) {
   const router = useRouter();
+
+  const tipsToBeTagged = tips;
 
   const { id } = router.query;
 
@@ -15,7 +17,7 @@ export default function PlantDetailsPage({ plants, onDeletePlant, handleEditPlan
   return (
     <main>
       <h1>Plant Details</h1>
-      <PlantDetails plant={plant} onDeletePlant={onDeletePlant} handleEditPlant={handleEditPlant} handleToggleModal={handleToggleModal} showModal={showModal} isDelete={isDelete} isEdit={isEdit} handleAddPlant={handleAddPlant} />
+      <PlantDetails plant={plant} onDeletePlant={onDeletePlant} handleEditPlant={handleEditPlant} handleToggleModal={handleToggleModal} showModal={showModal} isDelete={isDelete} isEdit={isEdit} handleAddPlant={handleAddPlant} tipsToBeTagged={tipsToBeTagged} />
     </main>
   );
 }

--- a/pages/plants/[id].js
+++ b/pages/plants/[id].js
@@ -1,7 +1,19 @@
 import { useRouter } from "next/router";
 import PlantDetails from "/components/PlantDetails/";
 
-export default function PlantDetailsPage({ plants, onDeletePlant, handleEditPlant, handleAddPlant, handleToggleModal, showModal, isEdit, isDelete, tips }) {
+export default function PlantDetailsPage({ 
+  plants, 
+  onDeletePlant, 
+  handleEditPlant, 
+  handleAddPlant, 
+  handleToggleModal, 
+  showModal, 
+  isEdit, 
+  isDelete, 
+  tips,
+  isOwned,
+  handleToggleOwned,
+  }) {
   const router = useRouter();
 
   const tipsToBeTagged = tips;
@@ -17,7 +29,19 @@ export default function PlantDetailsPage({ plants, onDeletePlant, handleEditPlan
   return (
     <main>
       <h1>Plant Details</h1>
-      <PlantDetails plant={plant} onDeletePlant={onDeletePlant} handleEditPlant={handleEditPlant} handleToggleModal={handleToggleModal} showModal={showModal} isDelete={isDelete} isEdit={isEdit} handleAddPlant={handleAddPlant} tipsToBeTagged={tipsToBeTagged} />
+      <PlantDetails 
+        plant={plant} 
+        onDeletePlant={onDeletePlant} 
+        handleEditPlant={handleEditPlant} 
+        handleToggleModal={handleToggleModal} 
+        showModal={showModal} 
+        isDelete={isDelete} 
+        isEdit={isEdit} 
+        handleAddPlant={handleAddPlant} 
+        tipsToBeTagged={tipsToBeTagged}
+        isOwned={isOwned}
+        handleToggleOwned={handleToggleOwned}
+         />
     </main>
   );
 }

--- a/pages/tips/[id].js
+++ b/pages/tips/[id].js
@@ -1,12 +1,14 @@
 import { useRouter } from "next/router";
 import TipDetails from "/components/TipDetails/";
 
-export default function TipDetailsPage({ tips }) {
+export default function TipDetailsPage({ tips, plants }) {
   const router = useRouter();
 
   const { id } = router.query;
 
   const tip = tips.find((tip) => tip.id === id);
+
+  const plantsToBeTagged = plants;
 
   if (!tip) {
     return <p>Plant tip not found!</p>;
@@ -21,7 +23,7 @@ export default function TipDetailsPage({ tips }) {
   return (
     <main>
       <h1>Care tips</h1>
-      <TipDetails tip={tip} />
+      <TipDetails tip={tip} plantsToBeTagged={plantsToBeTagged}/>
     </main>
   );
 }


### PR DESCRIPTION
Related US: https://github.com/StephMode/plant-pal/issues/25

The focus of this PR was to introduce new tag elements to the UI. These tag elments act as links between detail pages of plants and tips based on relationships defined in the respective `data.js` files. This feature enhances the user's ability to navigate the app more intuitively.

To achieve this, we:
- developed a `Tag` component that renders information about related plants on a tips detail page, and vice versa.
- styled the `Tag` components using `Styled Components` and `ThemeProvider` allowing the tags to blend into the diffrent designs of the two diffrent details pages.
- implemented routing back to the details page of plants and tips, so user can go back to the details page from which he came from before clicking the Tag for, improving UX.
- added states, logic and conditional rendering to the tips detail page to ensure the "Related Plants" section is hidden when there are no related plants in local storage, improving UI.

Additionally, as we worked intesively on the plants detail page, we also implemented the plant owned button there.


