### PR TITLE
Stephan fix 1 fix page routing

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -90,7 +90,7 @@ export default function App({ Component, pageProps }) {
         "https://images.unsplash.com/photo-1584589167171-541ce45f1eea?q=80&w=1974&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
     };
     setPlants([newPlant, ...plants]);
-    router.push(`/`);
+    router.push(`/home`);
   }
 
   function handleEditPlant(newPlantData, id) {
@@ -126,7 +126,7 @@ export default function App({ Component, pageProps }) {
   function handleDeletePlant(id) {
     setPlants((prevPlants) => prevPlants.filter((plant) => plant.id !== id));
 
-    router.push("/");
+    router.push("/home");
     setIsDelete(!isDelete);
     setShowModal(!showModal);
   }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -9,7 +9,6 @@ import { nanoid } from "nanoid";
 import { useEffect, useState, useRef } from "react";
 import Navigation from "/components/Navigation";
 import { Toaster } from 'react-hot-toast';
-import Link from "next/link";
 import styled from "styled-components";
 
 export default function App({ Component, pageProps }) {
@@ -126,7 +125,7 @@ export default function App({ Component, pageProps }) {
   function handleDeletePlant(id) {
     setPlants((prevPlants) => prevPlants.filter((plant) => plant.id !== id));
 
-    router.push("/home");
+    router.push(`/home`);
     setIsDelete(!isDelete);
     setShowModal(!showModal);
   }

--- a/pages/index.js
+++ b/pages/index.js
@@ -8,7 +8,7 @@ export default function IntroPage() {
 
     useEffect(() => {
       const timer = setTimeout(() => {
-        router.push('/home');
+        router.push(`/home`);
       }, 4500); 
       return () => clearTimeout(timer); 
     }, [router]);


### PR DESCRIPTION
This PR was about fixing bugs that occured after we changed the page structure in the app in https://github.com/StephMode/plant-pal/pull/39.

The issue was that after adding or deleting a plant, the user was redirected to the Intropage, which is now `index.js`. To achieve this we:
- we changed the `router.push` statements so that they lead to `home.js` which now holds our HomePage.
- we standardized the interpunction of `router.push` statements to single backticks so that we can have the same syntax for both static and dynamic routes.
 