### PR TITLE
Carmen feature set custom reminders

### DIFF
--- a/components/Navigation/index.js
+++ b/components/Navigation/index.js
@@ -6,6 +6,7 @@ import { FaPlus } from "react-icons/fa";
 import { IoHeart } from "react-icons/io5";
 import { RiPlantFill } from "react-icons/ri";
 import { RiCalendarScheduleFill } from "react-icons/ri";
+import { GoDotFill } from "react-icons/go";
 
 
 export default function Navigation() { 
@@ -37,6 +38,7 @@ export default function Navigation() {
                 </Link>
                 <Link href="/remindersPage" passHref>
                     <StyledIconContainer $isactive={router.asPath === "/remindersPage"}>
+                        <StyledNotificationIcon />
                         <RiCalendarScheduleFill />
                     </StyledIconContainer>
                 </Link>
@@ -71,3 +73,12 @@ const StyledNavContainer = styled.nav`
     color: var(--white);
     font-size: 2.2rem;
  `;
+
+const StyledNotificationIcon = styled(GoDotFill)`
+    color: var(--gold-dark);
+    position: relative;
+    right: -30px;
+    top: 4px;
+    opacity: 0.5;
+    z-index: 1;
+`;

--- a/components/Navigation/index.js
+++ b/components/Navigation/index.js
@@ -13,8 +13,8 @@ export default function Navigation({reminders, currentDate}) {
 
     const router = useRouter();
 
-    const showNotification = reminders.includes(currentDate);
-  
+    const showNotification = reminders.some(reminder => reminder.date <= currentDate);
+    
     return (
         <>
             <StyledNavContainer>

--- a/components/Navigation/index.js
+++ b/components/Navigation/index.js
@@ -5,6 +5,7 @@ import { HiHome } from "react-icons/hi";
 import { FaPlus } from "react-icons/fa";
 import { IoHeart } from "react-icons/io5";
 import { RiPlantFill } from "react-icons/ri";
+import { RiCalendarScheduleFill } from "react-icons/ri";
 
 
 export default function Navigation() { 
@@ -32,6 +33,11 @@ export default function Navigation() {
                 <Link href="/plantTipsPage" passHref>
                     <StyledIconContainer $isactive={router.asPath === "/plantTipsPage"}>
                         <RiPlantFill />
+                    </StyledIconContainer>
+                </Link>
+                <Link href="/remindersPage" passHref>
+                    <StyledIconContainer $isactive={router.asPath === "/remindersPage"}>
+                        <RiCalendarScheduleFill />
                     </StyledIconContainer>
                 </Link>
             </StyledNavContainer>

--- a/components/Navigation/index.js
+++ b/components/Navigation/index.js
@@ -9,10 +9,12 @@ import { RiCalendarScheduleFill } from "react-icons/ri";
 import { GoDotFill } from "react-icons/go";
 
 
-export default function Navigation() { 
+export default function Navigation({reminders, currentDate}) { 
 
     const router = useRouter();
 
+    const showNotification = reminders.includes(currentDate);
+  
     return (
         <>
             <StyledNavContainer>
@@ -38,7 +40,7 @@ export default function Navigation() {
                 </Link>
                 <Link href="/remindersPage" passHref>
                     <StyledIconContainer $isactive={router.asPath === "/remindersPage"}>
-                        <StyledNotificationIcon />
+                        {showNotification && <StyledNotificationIcon />}
                         <RiCalendarScheduleFill />
                     </StyledIconContainer>
                 </Link>

--- a/components/Navigation/index.js
+++ b/components/Navigation/index.js
@@ -18,8 +18,13 @@ export default function Navigation({reminders, currentDate}) {
         <>
             <StyledNavContainer>
                 <Link href="/home" passHref >
-                    <StyledIconContainer $isactive={router.asPath === "/"}>
+                    <StyledIconContainer $isactive={router.asPath === "/home"}>
                         <HiHome />
+                    </StyledIconContainer>
+                </Link>
+                <Link href="/plantTipsPage" passHref>
+                    <StyledIconContainer $isactive={router.asPath === "/plantTipsPage"}>
+                        <RiPlantFill />
                     </StyledIconContainer>
                 </Link>
                 <Link href="/addplant" passHref>
@@ -30,11 +35,6 @@ export default function Navigation({reminders, currentDate}) {
                 <Link href="/myplants" passHref>
                     <StyledIconContainer $isactive={router.asPath === "/myplants"}>
                         <IoHeart />
-                    </StyledIconContainer>
-                </Link>
-                <Link href="/plantTipsPage" passHref>
-                    <StyledIconContainer $isactive={router.asPath === "/plantTipsPage"}>
-                        <RiPlantFill />
                     </StyledIconContainer>
                 </Link>
                 <Link href="/remindersPage" passHref>

--- a/components/Navigation/index.js
+++ b/components/Navigation/index.js
@@ -47,7 +47,6 @@ export default function Navigation({reminders, currentDate}) {
                 </Link>
             </StyledNavContainer>
         </>
-
     )
 }
 

--- a/components/Navigation/index.js
+++ b/components/Navigation/index.js
@@ -1,12 +1,11 @@
 import Link from "next/link";
 import { useRouter } from "next/router";
-import styled from "styled-components"
+import styled, {ThemeProvider} from "styled-components"
 import { HiHome } from "react-icons/hi";
 import { FaPlus } from "react-icons/fa";
 import { IoHeart } from "react-icons/io5";
 import { RiPlantFill } from "react-icons/ri";
-import { RiCalendarScheduleFill } from "react-icons/ri";
-import { GoDotFill } from "react-icons/go";
+import { RiCalendarFill } from "react-icons/ri";
 
 
 export default function Navigation({reminders, currentDate}) { 
@@ -39,10 +38,12 @@ export default function Navigation({reminders, currentDate}) {
                     </StyledIconContainer>
                 </Link>
                 <Link href="/remindersPage" passHref>
+                    <ThemeProvider theme={showNotification ? notificationTheme : defaultTheme}>
+                    {showNotification && <StyledNotificationIcon></StyledNotificationIcon>}
                     <StyledIconContainer $isactive={router.asPath === "/remindersPage"}>
-                        {showNotification && <StyledNotificationIcon />}
-                        <RiCalendarScheduleFill />
+                        <RiCalendarFill />
                     </StyledIconContainer>
+                    </ThemeProvider>
                 </Link>
             </StyledNavContainer>
         </>
@@ -74,13 +75,34 @@ const StyledNavContainer = styled.nav`
     align-items: center;
     color: var(--white);
     font-size: 2.2rem;
+    position: ${props => props.theme.position};
+    top: ${props => props.theme.top};
  `;
 
-const StyledNotificationIcon = styled(GoDotFill)`
-    color: var(--gold-dark);
+
+const notificationTheme = {
+    position: "relative",
+    top: "-6px",
+}
+
+const defaultTheme = {
+    position: "static",
+    top: "none",
+}
+
+const StyledNotificationIcon = styled.span`
+    display: block;
+    background-color: var(--error-red);
+    border-radius: 50%;
+    height: 16px;
+    width: 16px;
     position: relative;
-    right: -30px;
-    top: 4px;
-    opacity: 0.5;
+    top: 16px;
+    right: -26px;
     z-index: 1;
 `;
+
+
+
+
+

--- a/components/PlantDetails/index.js
+++ b/components/PlantDetails/index.js
@@ -38,6 +38,7 @@ export default function PlantDetails({
   }) {
   const router = useRouter();
 
+  const relatedReminders = reminders.filter((reminder) => reminder.relatedPlant === plant.id);
   const relatedTips = tipsToBeTagged.filter((tip) => tip.relatedPlants.includes(plant.id));
 
   return (
@@ -118,7 +119,7 @@ export default function PlantDetails({
         </StyledEditDeleteSection>
         <StyledTipH3>Reminders:</StyledTipH3>
         <StyledListContainer>
-            {reminders.map((reminder) => 
+            {relatedReminders.map((reminder) => 
                 <li key={reminder.id}>
                     <ReminderCard task={reminder.task} date={reminder.date} />
                 </li>)}

--- a/components/PlantDetails/index.js
+++ b/components/PlantDetails/index.js
@@ -6,6 +6,7 @@ import Modal from "../Modal";
 import PlantDeleteSection from "../PlantDeleteSection";
 import Form from "../Form";
 import PlantOwnedButton from "../PlantOwnedButton";
+import ReminderCard from "../ReminderCard";
 import { RiDropLine } from "react-icons/ri";
 import { FaChevronLeft } from "react-icons/fa6";
 import { RiDropFill } from "react-icons/ri";
@@ -29,6 +30,7 @@ export default function PlantDetails({
   onDeletePlant, 
   tipsToBeTagged,
   handleToggleOwned,
+  reminders
   }) {
   const router = useRouter();
 
@@ -106,9 +108,17 @@ export default function PlantDetails({
         <StyledEditDeleteSection>
           <Button buttonText={<FaTrashAlt />} handleButtonFunction={() => handleToggleModal("Delete")} buttonRole={"deleteButton"}/>
         </StyledEditDeleteSection>
+        <StyledTipH3>Reminders:</StyledTipH3>
+        <StyledListContainer>
+            {reminders.map((reminder) => 
+                <li key={reminder.id}>
+                    <ReminderCard task={reminder.task} date={reminder.date} />
+                </li>)}
+            </StyledListContainer>
+
         <StyledTipH3>Related Care Tips:</StyledTipH3>
 
-          <StyledTagContainer>
+          <StyledListContainer>
               {relatedTips.map((tip) => (
                 <li key={tip.id}>
                   <Tag
@@ -121,7 +131,7 @@ export default function PlantDetails({
                 </li>
               ))}
             
-          </StyledTagContainer>
+          </StyledListContainer>
 
       </StyledPlantContainer>
 
@@ -258,7 +268,7 @@ const StyledFertilizerUl = styled.ul`
   font-weight: normal;
 `;
 
-const StyledTagContainer = styled.ul`
+const StyledListContainer = styled.ul`
   display: flex;
   justify-content:flex-start;
 `;

--- a/components/PlantDetails/index.js
+++ b/components/PlantDetails/index.js
@@ -117,7 +117,7 @@ export default function PlantDetails({
         <StyledEditDeleteSection>
           <Button buttonText={<FaTrashAlt />} handleButtonFunction={() => handleToggleModal("Delete")} buttonRole={"deleteButton"}/>
         </StyledEditDeleteSection>
-        <StyledTipH3>Reminders:</StyledTipH3>
+        {relatedReminders.length > 0 ? <StyledTipH3>Reminders:</StyledTipH3> : null}
         <StyledListContainer>
             {relatedReminders.map((reminder) => 
                 <li key={reminder.id}>

--- a/components/PlantDetails/index.js
+++ b/components/PlantDetails/index.js
@@ -57,18 +57,22 @@ export default function PlantDetails({
 
       <StyledPlantContainer>
         <StyledTopSection>
-          <StyledH2>{plant.name}</StyledH2>
-          <Button
-            buttonText={<RiCalendarScheduleFill />}
-            handleButtonFunction={() => handleToggleModal("Reminder")}
-          />
-          <Button
-            buttonText={<FaPen />}
-            handleButtonFunction={() => handleToggleModal("Edit")}
-          />
+          <StyledTopSectionHeadlineContainer>
+            <StyledH2>{plant.name}</StyledH2>
+            <StyledH3>{plant.botanicalName}</StyledH3>
+          </StyledTopSectionHeadlineContainer>
+          <StyledTopSectionIconContainer>
+            <Button
+              buttonText={<RiCalendarScheduleFill />}
+              handleButtonFunction={() => handleToggleModal("Reminder")}
+            />
+            <Button
+              buttonText={<FaPen />}
+              handleButtonFunction={() => handleToggleModal("Edit")}
+            />
+          </StyledTopSectionIconContainer>
         </StyledTopSection>
-        <StyledH3>{plant.botanicalName}</StyledH3>
-
+        
         <StyledDescription>{plant.description}</StyledDescription>
         <StyledPlantNeedsContainer>
           {plant.lightNeed === "Full Shade" ? (
@@ -260,15 +264,29 @@ const StyledIconSection = styled.section`
 `;
 const StyledTopSection = styled.section`
   display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 8px;
+`;
+
+const StyledTopSectionHeadlineContainer = styled.section`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  flex-grow: 3;
+`;
+
+const StyledTopSectionIconContainer = styled.section`
+  display: flex;
   flex-wrap: wrap;
   justify-content: flex-end;
-  gap: 12px;
+  gap: 8px;
+  flex-grow: 1;
 `;
+
+
 const StyledH2 = styled.h2`
   margin-bottom: 2px;
-  max-width: 260px;
-  margin-right: auto;
-  align-self: flex-start;
 `;
 const StyledH3 = styled.h3`
   margin-bottom: 15px;

--- a/components/PlantDetails/index.js
+++ b/components/PlantDetails/index.js
@@ -164,7 +164,7 @@ export default function PlantDetails({
               />
             ) : isReminder ? (
               <ReminderForm
-                plantName={plant.name}
+                plant={plant.name}
                 handleToggleModal={handleToggleModal}
                 handleAddReminder={handleAddReminder}
                 id={plant.id}

--- a/components/PlantDetails/index.js
+++ b/components/PlantDetails/index.js
@@ -33,7 +33,8 @@ export default function PlantDetails({
   tipsToBeTagged,
   handleToggleOwned,
   reminders,
-  isReminder
+  isReminder,
+  handleAddReminder
   }) {
   const router = useRouter();
 
@@ -165,6 +166,8 @@ export default function PlantDetails({
               <ReminderForm
                 plantName={plant.name}
                 handleToggleModal={handleToggleModal}
+                handleAddReminder={handleAddReminder}
+                id={plant.id}
               />
             )
              : (

--- a/components/PlantDetails/index.js
+++ b/components/PlantDetails/index.js
@@ -34,8 +34,7 @@ export default function PlantDetails({
   handleToggleOwned,
   reminders,
   isReminder,
-  handleAddReminder,
-  currentDate
+  handleAddReminder
   }) {
   const router = useRouter();
 
@@ -176,7 +175,6 @@ export default function PlantDetails({
                 handleToggleModal={handleToggleModal}
                 handleAddReminder={handleAddReminder}
                 id={plant.id}
-                currentDate={currentDate}
               />
             )
              : (

--- a/components/PlantDetails/index.js
+++ b/components/PlantDetails/index.js
@@ -7,6 +7,7 @@ import PlantDeleteSection from "../PlantDeleteSection";
 import Form from "../Form";
 import PlantOwnedButton from "../PlantOwnedButton";
 import ReminderCard from "../ReminderCard";
+import ReminderForm from "../ReminderForm";
 import { RiDropLine } from "react-icons/ri";
 import { FaChevronLeft } from "react-icons/fa6";
 import { RiDropFill } from "react-icons/ri";
@@ -17,6 +18,7 @@ import { IoMdMoon } from "react-icons/io";
 import { GiPowder } from "react-icons/gi";
 import { FaTrashAlt } from "react-icons/fa";
 import { FaPen } from "react-icons/fa6";
+import { RiCalendarScheduleFill } from "react-icons/ri";
 import { useRouter } from "next/router";
 
 export default function PlantDetails({ 
@@ -30,7 +32,8 @@ export default function PlantDetails({
   onDeletePlant, 
   tipsToBeTagged,
   handleToggleOwned,
-  reminders
+  reminders,
+  isReminder
   }) {
   const router = useRouter();
 
@@ -52,6 +55,10 @@ export default function PlantDetails({
       <StyledPlantContainer>
         <StyledTopSection>
           <StyledH2>{plant.name}</StyledH2>
+          <Button
+            buttonText={<RiCalendarScheduleFill />}
+            handleButtonFunction={() => handleToggleModal("Reminder")}
+          />
           <Button
             buttonText={<FaPen />}
             handleButtonFunction={() => handleToggleModal("Edit")}
@@ -154,7 +161,13 @@ export default function PlantDetails({
                 id={plant.id}
                 handleToggleModal={handleToggleModal}
               />
-            ) : (
+            ) : isReminder ? (
+              <ReminderForm
+                plantName={plant.name}
+                handleToggleModal={handleToggleModal}
+              />
+            )
+             : (
               "This is an error, please reload page."
             )
           }

--- a/components/PlantDetails/index.js
+++ b/components/PlantDetails/index.js
@@ -261,11 +261,14 @@ const StyledIconSection = styled.section`
 const StyledTopSection = styled.section`
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-between;
+  justify-content: flex-end;
+  gap: 12px;
 `;
 const StyledH2 = styled.h2`
   margin-bottom: 2px;
   max-width: 260px;
+  margin-right: auto;
+  align-self: flex-start;
 `;
 const StyledH3 = styled.h3`
   margin-bottom: 15px;

--- a/components/PlantDetails/index.js
+++ b/components/PlantDetails/index.js
@@ -120,7 +120,9 @@ export default function PlantDetails({
         </StyledEditDeleteSection>
         {relatedReminders.length > 0 ? <StyledTipH3>Reminders:</StyledTipH3> : null}
         <StyledListContainer>
-            {relatedReminders.map((reminder) => 
+            {relatedReminders
+            .sort((a, b) => new Date(a.date) - new Date(b.date))
+            .map((reminder) => 
                 <li key={reminder.id}>
                     <ReminderCard task={reminder.task} date={reminder.date} />
                 </li>)}

--- a/components/PlantDetails/index.js
+++ b/components/PlantDetails/index.js
@@ -34,7 +34,8 @@ export default function PlantDetails({
   handleToggleOwned,
   reminders,
   isReminder,
-  handleAddReminder
+  handleAddReminder,
+  currentDate
   }) {
   const router = useRouter();
 
@@ -169,6 +170,7 @@ export default function PlantDetails({
                 handleToggleModal={handleToggleModal}
                 handleAddReminder={handleAddReminder}
                 id={plant.id}
+                currentDate={currentDate}
               />
             )
              : (

--- a/components/ReminderCard/index.js
+++ b/components/ReminderCard/index.js
@@ -2,7 +2,7 @@ import styled, {ThemeProvider} from "styled-components";
 import { RiCalendarScheduleFill } from "react-icons/ri";
 
 
-export default function ReminderCard({plantName, task, date, reminderPage}) {
+export default function ReminderCard({plantName, task, date, reminderPage, handleDeleteReminder}) {
 
     return (
         <ThemeProvider theme={reminderPage ? reminderPageTheme : plantDetailsPageTheme}>
@@ -12,7 +12,7 @@ export default function ReminderCard({plantName, task, date, reminderPage}) {
                 </StyledIconContainer>
                 {reminderPage && <h2>{plantName}</h2>}
                 <StyledReminderContent><b>{task}:</b> {date}</StyledReminderContent>
-                {reminderPage && <StyledButton type="button">Mark as done</StyledButton>}
+                {reminderPage && <StyledButton type="button" onClick={() => handleDeleteReminder(id)}>Mark as done</StyledButton>}
             </StyledReminderCard>
         </ThemeProvider>
     );

--- a/components/ReminderCard/index.js
+++ b/components/ReminderCard/index.js
@@ -23,6 +23,7 @@ const reminderPageTheme = {
     width: "350px",
     minWidth: "330px",
     marginLeft: "0px",
+    marginBottom: "10px",
     alignSelf: "flex-end",
     boxShadow: "0 0px 15px rgba(0, 0, 0, 0.3)",
     backgroundColor: "var(--white)",
@@ -32,6 +33,7 @@ const plantDetailsPageTheme = {
     width: "300px",
     minWidth: "300px",
     marginLeft: "40px",
+    marginBottom: "0px",
     alignSelf: "flex-start",
     boxShadow: "none",
     backgroundColor: "rgb(240, 240, 240)",
@@ -44,7 +46,7 @@ const StyledReminderCard = styled.article`
     flex-direction: column;
     padding: 10px 15px;
     border-radius: 25px;
-    margin-bottom: 10px;
+    margin-bottom: ${props => props.theme.marginBottom};
     width: ${props => props.theme.width};
     justify-content: flex-start;
     box-shadow: ${props => props.theme.boxShadow};

--- a/components/ReminderCard/index.js
+++ b/components/ReminderCard/index.js
@@ -24,6 +24,8 @@ const reminderPageTheme = {
     minWidth: "330px",
     marginLeft: "0px",
     alignSelf: "flex-end",
+    boxShadow: "0 0px 15px rgba(0, 0, 0, 0.3)",
+    backgroundColor: "var(--white)",
 };
 
 const plantDetailsPageTheme = {
@@ -31,11 +33,13 @@ const plantDetailsPageTheme = {
     minWidth: "300px",
     marginLeft: "40px",
     alignSelf: "flex-start",
+    boxShadow: "none",
+    backgroundColor: "rgb(240, 240, 240)",
 };
 
 
 const StyledReminderCard = styled.article`
-    background-color: var(--white);
+    background-color: ${props => props.theme.backgroundColor};
     display: flex;
     flex-direction: column;
     padding: 10px 15px;
@@ -43,7 +47,7 @@ const StyledReminderCard = styled.article`
     margin-bottom: 10px;
     width: ${props => props.theme.width};
     justify-content: flex-start;
-    box-shadow: 0 0px 15px rgba(0, 0, 0, 0.3);
+    box-shadow: ${props => props.theme.boxShadow};
 
   @media (max-width: 750px) {
     width: ${props => props.theme.minWidth};

--- a/components/ReminderCard/index.js
+++ b/components/ReminderCard/index.js
@@ -12,7 +12,7 @@ export default function ReminderCard({plantName, task, date, id, reminderPage, h
                 </StyledIconContainer>
                 {reminderPage && <h2>{plantName}</h2>}
                 <StyledReminderContent><b>{task}:</b> {date}</StyledReminderContent>
-                {reminderPage && <StyledButton type="button" onClick={() => handleDeleteReminder(id)}>Mark as done</StyledButton>}
+                {reminderPage && <StyledButton type="button" onClick={() => handleDeleteReminder(id, task)}>Mark as done</StyledButton>}
             </StyledReminderCard>
         </ThemeProvider>
     );

--- a/components/ReminderCard/index.js
+++ b/components/ReminderCard/index.js
@@ -1,0 +1,15 @@
+import { RiCalendarScheduleFill } from "react-icons/ri";
+import Button from "../Button";
+
+export default function ReminderCard({plantName, task, date, reminderPage}) {
+
+    return (
+        <article>
+            <RiCalendarScheduleFill />
+            {reminderPage && <p>{plantName}</p>}
+            <p>{task}</p>
+            <p>{date}</p>
+            {reminderPage && <Button buttontext="Mark as done" />}
+        </article>
+    );
+}

--- a/components/ReminderCard/index.js
+++ b/components/ReminderCard/index.js
@@ -66,7 +66,9 @@ const StyledReminderContent = styled.p`
 `;
 
 const StyledH2 = styled.h2`
-&:hover {
+    max-width: 260px;
+    
+    &:hover {
     color: var(--green-light-dark);
     transition: all 0.45s ease 0s;
   }

--- a/components/ReminderCard/index.js
+++ b/components/ReminderCard/index.js
@@ -9,7 +9,7 @@ export default function ReminderCard({plantName, task, date, reminderPage}) {
             {reminderPage && <p>{plantName}</p>}
             <p>{task}</p>
             <p>{date}</p>
-            {reminderPage && <Button buttontext="Mark as done" />}
+            {reminderPage && <Button buttonText="Mark as done" />}
         </article>
     );
 }

--- a/components/ReminderCard/index.js
+++ b/components/ReminderCard/index.js
@@ -2,7 +2,7 @@ import styled, {ThemeProvider} from "styled-components";
 import { RiCalendarScheduleFill } from "react-icons/ri";
 
 
-export default function ReminderCard({plantName, task, date, reminderPage, handleDeleteReminder}) {
+export default function ReminderCard({plantName, task, date, id, reminderPage, handleDeleteReminder}) {
 
     return (
         <ThemeProvider theme={reminderPage ? reminderPageTheme : plantDetailsPageTheme}>

--- a/components/ReminderCard/index.js
+++ b/components/ReminderCard/index.js
@@ -1,8 +1,9 @@
 import styled, {ThemeProvider} from "styled-components";
 import { RiCalendarScheduleFill } from "react-icons/ri";
+import Link from "next/link";
 
 
-export default function ReminderCard({plantName, task, date, id, reminderPage, handleDeleteReminder}) {
+export default function ReminderCard({plantName, task, date, id, reminderPage, handleDeleteReminder, plantId}) {
 
     return (
         <ThemeProvider theme={reminderPage ? reminderPageTheme : plantDetailsPageTheme}>
@@ -10,7 +11,11 @@ export default function ReminderCard({plantName, task, date, id, reminderPage, h
                 <StyledIconContainer>
                     <RiCalendarScheduleFill />
                 </StyledIconContainer>
-                {reminderPage && <h2>{plantName}</h2>}
+                {reminderPage && 
+                 <Link href={`/plants/${plantId}`}>
+                    <StyledH2>{plantName}</StyledH2>
+                </Link>
+                }
                 <StyledReminderContent><b>{task}:</b> {date}</StyledReminderContent>
                 {reminderPage && <StyledButton type="button" onClick={() => handleDeleteReminder(id, task)}>Mark as done</StyledButton>}
             </StyledReminderCard>
@@ -60,6 +65,12 @@ const StyledReminderContent = styled.p`
     margin-left: ${props => props.theme.marginLeft};
 `;
 
+const StyledH2 = styled.h2`
+&:hover {
+    color: var(--green-light-dark);
+    transition: all 0.45s ease 0s;
+  }
+`;
 
 const StyledIconContainer = styled.span`
     align-self: ${props => props.theme.alignSelf};

--- a/components/ReminderCard/index.js
+++ b/components/ReminderCard/index.js
@@ -1,21 +1,37 @@
-import styled from "styled-components";
+import styled, {ThemeProvider} from "styled-components";
 import { RiCalendarScheduleFill } from "react-icons/ri";
-import Button from "../Button";
+
 
 export default function ReminderCard({plantName, task, date, reminderPage}) {
 
     return (
+        <ThemeProvider theme={reminderPage ? reminderPageTheme : plantDetailsPageTheme}>
             <StyledReminderCard>
                 <StyledIconContainer>
                     <RiCalendarScheduleFill />
                 </StyledIconContainer>
                 {reminderPage && <h2>{plantName}</h2>}
-                <p><b>{task}:</b> {date}</p>
+                <StyledReminderContent><b>{task}:</b> {date}</StyledReminderContent>
                 {reminderPage && <StyledButton type="button">Mark as done</StyledButton>}
             </StyledReminderCard>
+        </ThemeProvider>
     );
 }
 
+
+const reminderPageTheme = {
+    width: "350px",
+    minWidth: "330px",
+    marginLeft: "0px",
+    alignSelf: "flex-end",
+};
+
+const plantDetailsPageTheme = {
+    width: "300px",
+    minWidth: "300px",
+    marginLeft: "40px",
+    alignSelf: "flex-start",
+};
 
 
 const StyledReminderCard = styled.article`
@@ -25,18 +41,22 @@ const StyledReminderCard = styled.article`
     padding: 10px 15px;
     border-radius: 25px;
     margin-bottom: 10px;
-    width: 350px;
+    width: ${props => props.theme.width};
     justify-content: flex-start;
     box-shadow: 0 0px 15px rgba(0, 0, 0, 0.3);
 
   @media (max-width: 750px) {
-    width: 330px;
+    width: ${props => props.theme.minWidth};
   }
+`;
+
+const StyledReminderContent = styled.p`
+    margin-left: ${props => props.theme.marginLeft};
 `;
 
 
 const StyledIconContainer = styled.span`
-    align-self: flex-end;
+    align-self: ${props => props.theme.alignSelf};
     font-size: 1.5rem;
     position: absolute;
     color: var(--black);

--- a/components/ReminderCard/index.js
+++ b/components/ReminderCard/index.js
@@ -3,11 +3,32 @@ import { RiCalendarScheduleFill } from "react-icons/ri";
 import Link from "next/link";
 
 
-export default function ReminderCard({plantName, task, date, id, reminderPage, handleDeleteReminder, plantId}) {
+export default function ReminderCard({
+    plantName, 
+    task, 
+    date, 
+    id, 
+    reminderPage, 
+    handleDeleteReminder, 
+    plantId}) {
 
     return (
         <ThemeProvider theme={reminderPage ? reminderPageTheme : plantDetailsPageTheme}>
-            {!reminderPage ? (
+            {reminderPage ? 
+            (
+             <StyledReminderCard>
+                <StyledIconContainer>
+                    <RiCalendarScheduleFill />
+                </StyledIconContainer>
+                <Link href={`/plants/${plantId}`}>
+                    <StyledH2>{plantName}</StyledH2>
+                </Link>
+                <StyledReminderContent><b>{task}:</b> {date}</StyledReminderContent>
+                <StyledButton type="button" onClick={() => handleDeleteReminder(id, task)}>Mark as done</StyledButton>
+            </StyledReminderCard>
+            )
+            :
+            (
             <Link href='/remindersPage'>
                 <StyledReminderCard>
                     <StyledIconContainer>
@@ -15,18 +36,7 @@ export default function ReminderCard({plantName, task, date, id, reminderPage, h
                     </StyledIconContainer>
                     <StyledReminderContent><b>{task}:</b> {date}</StyledReminderContent>
                 </StyledReminderCard>
-            </Link> )
-            : (
-                <StyledReminderCard>
-                    <StyledIconContainer>
-                        <RiCalendarScheduleFill />
-                    </StyledIconContainer>
-                    <Link href={`/plants/${plantId}`}>
-                        <StyledH2>{plantName}</StyledH2>
-                    </Link>
-                    <StyledReminderContent><b>{task}:</b> {date}</StyledReminderContent>
-                    <StyledButton type="button" onClick={() => handleDeleteReminder(id, task)}>Mark as done</StyledButton>
-                </StyledReminderCard>
+            </Link>
             )}
         </ThemeProvider>
     );
@@ -57,7 +67,6 @@ const plantDetailsPageTheme = {
     transition: "all 0.45s ease 0s"
 };
 
-
 const StyledReminderCard = styled.article`
     background-color: ${props => props.theme.backgroundColor};
     display: flex;
@@ -73,7 +82,6 @@ const StyledReminderCard = styled.article`
         background-color: ${props => props.theme.backgroundColorHover};
         transition: ${props => props.theme.transition};
     }
-
 
   @media (max-width: 750px) {
     width: ${props => props.theme.minWidth};
@@ -117,12 +125,4 @@ const StyledButton = styled.button`
     background-color: var(--brown-dark);
     color: var(--white);
   }
-`;
-
-const StyledLink = styled(Link)`
-    &:hover {
-    background-color: var(--gray-dark);
-    color: var(--white);
-    transition: all 0.45s ease 0s;
-    }
 `;

--- a/components/ReminderCard/index.js
+++ b/components/ReminderCard/index.js
@@ -49,14 +49,14 @@ const StyledButton = styled.button`
     margin: 10px 0 5px 0;
     border: none;
     border-radius: 20px;
-    background-color: var(--green-light);
+    background-color: var(--brown);
     color: var(-green-main);
     font-size: 14px;
     cursor: pointer;
     transition: 0.5s ease-in-out;
 
     &:hover {
-    background-color: var(--green-light-dark);
+    background-color: var(--brown-dark);
     color: var(--white);
   }
 `;

--- a/components/ReminderCard/index.js
+++ b/components/ReminderCard/index.js
@@ -7,18 +7,27 @@ export default function ReminderCard({plantName, task, date, id, reminderPage, h
 
     return (
         <ThemeProvider theme={reminderPage ? reminderPageTheme : plantDetailsPageTheme}>
-            <StyledReminderCard>
-                <StyledIconContainer>
-                    <RiCalendarScheduleFill />
-                </StyledIconContainer>
-                {reminderPage && 
-                 <Link href={`/plants/${plantId}`}>
-                    <StyledH2>{plantName}</StyledH2>
-                </Link>
-                }
-                <StyledReminderContent><b>{task}:</b> {date}</StyledReminderContent>
-                {reminderPage && <StyledButton type="button" onClick={() => handleDeleteReminder(id, task)}>Mark as done</StyledButton>}
-            </StyledReminderCard>
+            {!reminderPage ? (
+            <Link href='/remindersPage'>
+                <StyledReminderCard>
+                    <StyledIconContainer>
+                        <RiCalendarScheduleFill />
+                    </StyledIconContainer>
+                    <StyledReminderContent><b>{task}:</b> {date}</StyledReminderContent>
+                </StyledReminderCard>
+            </Link> )
+            : (
+                <StyledReminderCard>
+                    <StyledIconContainer>
+                        <RiCalendarScheduleFill />
+                    </StyledIconContainer>
+                    <Link href={`/plants/${plantId}`}>
+                        <StyledH2>{plantName}</StyledH2>
+                    </Link>
+                    <StyledReminderContent><b>{task}:</b> {date}</StyledReminderContent>
+                    <StyledButton type="button" onClick={() => handleDeleteReminder(id, task)}>Mark as done</StyledButton>
+                </StyledReminderCard>
+            )}
         </ThemeProvider>
     );
 }
@@ -31,7 +40,9 @@ const reminderPageTheme = {
     marginBottom: "10px",
     alignSelf: "flex-end",
     boxShadow: "0 0px 15px rgba(0, 0, 0, 0.3)",
-    backgroundColor: "var(--white)",
+    backgroundColor: "var(--white)", 
+    backgroundColorHover: "none",
+    transition: "none"  
 };
 
 const plantDetailsPageTheme = {
@@ -42,6 +53,8 @@ const plantDetailsPageTheme = {
     alignSelf: "flex-start",
     boxShadow: "none",
     backgroundColor: "rgb(240, 240, 240)",
+    backgroundColorHover: "var(--gray)",
+    transition: "all 0.45s ease 0s"
 };
 
 
@@ -56,6 +69,12 @@ const StyledReminderCard = styled.article`
     justify-content: flex-start;
     box-shadow: ${props => props.theme.boxShadow};
 
+    &:hover {
+        background-color: ${props => props.theme.backgroundColorHover};
+        transition: ${props => props.theme.transition};
+    }
+
+
   @media (max-width: 750px) {
     width: ${props => props.theme.minWidth};
   }
@@ -67,7 +86,7 @@ const StyledReminderContent = styled.p`
 
 const StyledH2 = styled.h2`
     max-width: 260px;
-    
+
     &:hover {
     color: var(--green-light-dark);
     transition: all 0.45s ease 0s;
@@ -98,4 +117,12 @@ const StyledButton = styled.button`
     background-color: var(--brown-dark);
     color: var(--white);
   }
+`;
+
+const StyledLink = styled(Link)`
+    &:hover {
+    background-color: var(--gray-dark);
+    color: var(--white);
+    transition: all 0.45s ease 0s;
+    }
 `;

--- a/components/ReminderCard/index.js
+++ b/components/ReminderCard/index.js
@@ -1,15 +1,62 @@
+import styled from "styled-components";
 import { RiCalendarScheduleFill } from "react-icons/ri";
 import Button from "../Button";
 
 export default function ReminderCard({plantName, task, date, reminderPage}) {
 
     return (
-        <article>
-            <RiCalendarScheduleFill />
-            {reminderPage && <p>{plantName}</p>}
-            <p>{task}</p>
-            <p>{date}</p>
-            {reminderPage && <Button buttonText="Mark as done" />}
-        </article>
+            <StyledReminderCard>
+                <StyledIconContainer>
+                    <RiCalendarScheduleFill />
+                </StyledIconContainer>
+                {reminderPage && <h2>{plantName}</h2>}
+                <p><b>{task}:</b> {date}</p>
+                {reminderPage && <StyledButton type="button">Mark as done</StyledButton>}
+            </StyledReminderCard>
     );
 }
+
+
+
+const StyledReminderCard = styled.article`
+    background-color: var(--white);
+    display: flex;
+    flex-direction: column;
+    padding: 10px 15px;
+    border-radius: 25px;
+    margin-bottom: 10px;
+    width: 350px;
+    justify-content: flex-start;
+    box-shadow: 0 0px 15px rgba(0, 0, 0, 0.3);
+
+  @media (max-width: 750px) {
+    width: 330px;
+  }
+`;
+
+
+const StyledIconContainer = styled.span`
+    align-self: flex-end;
+    font-size: 1.5rem;
+    position: absolute;
+    color: var(--black);
+`;
+
+const StyledButton = styled.button`
+    width: 140px;
+    align-self: center;
+    padding: 8px 10px 6px;
+    margin: 10px 0 5px 0;
+    border: none;
+    border-radius: 20px;
+    background-color: var(--green-light);
+    color: var(-green-main);
+    font-size: 14px;
+    cursor: pointer;
+    transition: 0.5s ease-in-out;
+
+    &:hover {
+    background-color: var(--green-light-dark);
+    color: var(--white);
+  }
+`;

--- a/components/ReminderForm/index.js
+++ b/components/ReminderForm/index.js
@@ -1,14 +1,30 @@
 import styled, {ThemeProvider}  from "styled-components";
 import { useState } from "react";
 import { IoClose } from "react-icons/io5";
+import toast from 'react-hot-toast';
 
-export default function ReminderForm({plantName, handleToggleModal}) {
+export default function ReminderForm({plantName, handleToggleModal, handleAddReminder, id}) {
 
     const [showErrorMessageTask, setShowErrorMessageTask] = useState(false);
 
+    function handleSubmitReminder(event) {
+        event.preventDefault();
+    
+        const formData = new FormData(event.target);
+        const data = Object.fromEntries(formData);
+        
+        if (data.task === "") {
+            toast.error("Some reminder details are missing");
+            if (data.task === "") {setShowErrorMessageTask(true)};
+        } else {
+          handleAddReminder(data, id); toast.success("Reminder successfully created") 
+        }
+          event.target.reset();
+        };
+
     return (
         <StyledSection>
-            <form>
+            <form onSubmit={handleSubmitReminder}>
                 <StyledCloseButton type="button" onClick={() => handleToggleModal("Reminder")}>
                     <IoClose />
                 </StyledCloseButton>

--- a/components/ReminderForm/index.js
+++ b/components/ReminderForm/index.js
@@ -3,9 +3,11 @@ import { useState } from "react";
 import { IoClose } from "react-icons/io5";
 import toast from 'react-hot-toast';
 
-export default function ReminderForm({plant, handleToggleModal, handleAddReminder, id}) {
+export default function ReminderForm({plant, handleToggleModal, handleAddReminder, id, currentDate}) {
 
     const [showErrorMessageTask, setShowErrorMessageTask] = useState(false);
+    const [showErrorMessageDate, setShowErrorMessageDate] = useState(false);
+
 
     function handleSubmitReminder(event) {
         event.preventDefault();
@@ -13,13 +15,14 @@ export default function ReminderForm({plant, handleToggleModal, handleAddReminde
         const formData = new FormData(event.target);
         const data = Object.fromEntries(formData);
         
-        if (data.task === "") {
+        if (data.task === "" || data.date === "") {
             toast.error("Some reminder details are missing");
             if (data.task === "") {setShowErrorMessageTask(true)};
+            if (data.date === "") {setShowErrorMessageDate(true)};
         } else {
-          handleAddReminder(data, id, plant); toast.success("Reminder successfully created") 
+          handleAddReminder(data, id, plant); toast.success("Reminder successfully created");
+          event.target.reset(); 
         }
-          event.target.reset();
         };
 
     return (
@@ -43,11 +46,15 @@ export default function ReminderForm({plant, handleToggleModal, handleAddReminde
                 </StyledFieldset>
                 <StyledFieldset>
                     <label htmlFor="date">Date:</label>
+                    <ThemeProvider theme={showErrorMessageDate ? errorMessagetheme : defaultTheme}>
                         <StyledInput
                             id="date"
                             name="date"
                             type="date"
+                            onChange={() => {setShowErrorMessageDate(false)}}
                         ></StyledInput>
+                    </ThemeProvider>
+                    <StyledErrorMessage>{showErrorMessageDate && "Please pick a date."}&nbsp;</StyledErrorMessage>
                 </StyledFieldset>
                 <StyledButtonContainer>
                     <StyledSubmitButton type="submit">

--- a/components/ReminderForm/index.js
+++ b/components/ReminderForm/index.js
@@ -1,0 +1,19 @@
+import Button from "../Button";
+
+export default function ReminderForm() {
+    return (
+        <form>
+            <h2>Create Reminder for {plantName}</h2>
+            <label htmlFor="task">
+                <input type="text" id="task" name="task" placeholder="e.g. watering"></input> 
+            </label>
+            <label htmlFor="date">
+                <input type="date" id="date" name="date"></input> 
+            </label>
+            <Button buttonText="Cancel" />
+            <button type="submit">Create Reminder</button>
+        </form>
+
+    );
+}
+

--- a/components/ReminderForm/index.js
+++ b/components/ReminderForm/index.js
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { IoClose } from "react-icons/io5";
 import toast from 'react-hot-toast';
 
-export default function ReminderForm({plant, handleToggleModal, handleAddReminder, id, currentDate}) {
+export default function ReminderForm({plant, handleToggleModal, handleAddReminder, id}) {
 
     const [showErrorMessageTask, setShowErrorMessageTask] = useState(false);
     const [showErrorMessageDate, setShowErrorMessageDate] = useState(false);
@@ -58,7 +58,7 @@ export default function ReminderForm({plant, handleToggleModal, handleAddReminde
                 </StyledFieldset>
                 <StyledButtonContainer>
                     <StyledSubmitButton type="submit">
-                        Create Reminder for {plant}
+                        Create Reminder
                     </StyledSubmitButton>
                 </StyledButtonContainer>
             </form>

--- a/components/ReminderForm/index.js
+++ b/components/ReminderForm/index.js
@@ -3,7 +3,11 @@ import { useState } from "react";
 import { IoClose } from "react-icons/io5";
 import toast from 'react-hot-toast';
 
-export default function ReminderForm({plant, handleToggleModal, handleAddReminder, id}) {
+export default function ReminderForm({
+  plant,
+  handleToggleModal,
+  handleAddReminder,
+  id}) {
 
     const [showErrorMessageTask, setShowErrorMessageTask] = useState(false);
     const [showErrorMessageDate, setShowErrorMessageDate] = useState(false);
@@ -114,14 +118,17 @@ const StyledInput = styled.input`
     outline-color: var(--green-light);
   }
 `;
+
 StyledInput.defaultProps = {
   theme: {
     main: "rgba(0,0,0,0.1)"
   }
 }
+
 const defaultTheme = {
   main: "rgba(0,0,0,0.1)"
 }
+
 const errorMessagetheme = {
   main: "var(--error-red)"
 }

--- a/components/ReminderForm/index.js
+++ b/components/ReminderForm/index.js
@@ -1,22 +1,43 @@
-import Button from "../Button";
-import styled from "styled-components";
+import styled, {ThemeProvider}  from "styled-components";
+import { useState } from "react";
 import { IoClose } from "react-icons/io5";
 
 export default function ReminderForm({plantName, handleToggleModal}) {
+
+    const [showErrorMessageTask, setShowErrorMessageTask] = useState(false);
+
     return (
         <StyledSection>
             <form>
                 <StyledCloseButton type="button" onClick={() => handleToggleModal("Reminder")}>
-                <IoClose />
+                    <IoClose />
                 </StyledCloseButton>
-                <h2>Create Reminder for {plantName}</h2>
-                <label htmlFor="task">
-                    <input type="text" id="task" name="task" placeholder="e.g. watering"></input> 
-                </label>
-                <label htmlFor="date">
-                    <input type="date" id="date" name="date"></input> 
-                </label>
-                <button type="submit">Create Reminder</button>
+                <StyledFieldset>
+                    <label htmlFor="task">Task:</label>
+                    <ThemeProvider theme={showErrorMessageTask ? errorMessagetheme : defaultTheme}>
+                        <StyledInput
+                            id="task"
+                            name="task"
+                            type="text"
+                            placeholder="e.g. Watering"
+                            onChange={() => {setShowErrorMessageTask(false)}}           
+                        ></StyledInput>
+                    </ThemeProvider>
+                    <StyledErrorMessage>{showErrorMessageTask && "Please insert a task description."}&nbsp;</StyledErrorMessage>
+                </StyledFieldset>
+                <StyledFieldset>
+                    <label htmlFor="date">Date:</label>
+                        <StyledInput
+                            id="date"
+                            name="date"
+                            type="date"
+                        ></StyledInput>
+                </StyledFieldset>
+                <StyledButtonContainer>
+                    <StyledSubmitButton type="submit">
+                        Create Reminder for {plantName}
+                    </StyledSubmitButton>
+                </StyledButtonContainer>
             </form>
         </StyledSection>
 
@@ -29,6 +50,15 @@ const StyledSection = styled.section`
   border-radius: 25px;
   max-width: 600px;
   min-width: 350px;
+`;
+
+const StyledFieldset = styled.fieldset`
+  flex-direction: column;
+  display: flex;
+  border: none;
+  padding: 2px 0;
+  color: var(--green-main);
+  text-align: left;
 `;
 
 const StyledCloseButton = styled.button`
@@ -45,4 +75,60 @@ const StyledCloseButton = styled.button`
   &:hover {
     background-color: var(--brown-dark);
   }
+`;
+
+const StyledInput = styled.input`
+  border: none;
+  border-radius: 30px;
+  padding: 10px 15px;
+  margin-top: 6px;
+  font-family: inherit;
+
+  background-color: rgba(0,0,0,0.1);
+  border: 2px solid ${props => props.theme.main};
+
+  &:focus {
+    outline-color: var(--green-light);
+  }
+`;
+StyledInput.defaultProps = {
+  theme: {
+    main: "rgba(0,0,0,0.1)"
+  }
+}
+const defaultTheme = {
+  main: "rgba(0,0,0,0.1)"
+}
+const errorMessagetheme = {
+  main: "var(--error-red)"
+}
+
+const StyledErrorMessage = styled.p`
+  color: var(--error-red);
+  font-size: 0.75rem;
+  margin-left: 15px;
+  padding-top: 5px;
+`;
+
+const StyledSubmitButton = styled.button`
+  padding: 10px 15px;
+  background-color: var(--brown);
+  color: var(--black);
+  font-weight: bold;
+  border: none;
+  border-radius: 20px;
+  width: 100%;
+  margin-top: 10px;
+  transition: all ease-in-out 0.5s;
+
+  &:hover {
+    background-color: var(--green-main-dark);
+    cursor: pointer;
+    color: var(--white);
+  }
+`;
+
+const StyledButtonContainer = styled.section`
+  display: flex;
+  gap: 15px;
 `;

--- a/components/ReminderForm/index.js
+++ b/components/ReminderForm/index.js
@@ -1,19 +1,48 @@
 import Button from "../Button";
+import styled from "styled-components";
+import { IoClose } from "react-icons/io5";
 
-export default function ReminderForm() {
+export default function ReminderForm({plantName, handleToggleModal}) {
     return (
-        <form>
-            <h2>Create Reminder for {plantName}</h2>
-            <label htmlFor="task">
-                <input type="text" id="task" name="task" placeholder="e.g. watering"></input> 
-            </label>
-            <label htmlFor="date">
-                <input type="date" id="date" name="date"></input> 
-            </label>
-            <Button buttonText="Cancel" />
-            <button type="submit">Create Reminder</button>
-        </form>
+        <StyledSection>
+            <form>
+                <StyledCloseButton type="button" onClick={() => handleToggleModal("Reminder")}>
+                <IoClose />
+                </StyledCloseButton>
+                <h2>Create Reminder for {plantName}</h2>
+                <label htmlFor="task">
+                    <input type="text" id="task" name="task" placeholder="e.g. watering"></input> 
+                </label>
+                <label htmlFor="date">
+                    <input type="date" id="date" name="date"></input> 
+                </label>
+                <button type="submit">Create Reminder</button>
+            </form>
+        </StyledSection>
 
     );
 }
 
+
+const StyledSection = styled.section`
+  padding: 15px;
+  border-radius: 25px;
+  max-width: 600px;
+  min-width: 350px;
+`;
+
+const StyledCloseButton = styled.button`
+  background-color: var(--brown);
+  border: none;
+  border-radius: 20px;
+  padding: 5px 6px 0px 6px;
+  font-size: 26px;
+  position: absolute;
+  top: -10px;
+  right: -10px;
+  transition: all ease-in-out 0.5s;
+
+  &:hover {
+    background-color: var(--brown-dark);
+  }
+`;

--- a/components/ReminderForm/index.js
+++ b/components/ReminderForm/index.js
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { IoClose } from "react-icons/io5";
 import toast from 'react-hot-toast';
 
-export default function ReminderForm({plantName, handleToggleModal, handleAddReminder, id}) {
+export default function ReminderForm({plant, handleToggleModal, handleAddReminder, id}) {
 
     const [showErrorMessageTask, setShowErrorMessageTask] = useState(false);
 
@@ -17,7 +17,7 @@ export default function ReminderForm({plantName, handleToggleModal, handleAddRem
             toast.error("Some reminder details are missing");
             if (data.task === "") {setShowErrorMessageTask(true)};
         } else {
-          handleAddReminder(data, id); toast.success("Reminder successfully created") 
+          handleAddReminder(data, id, plant); toast.success("Reminder successfully created") 
         }
           event.target.reset();
         };
@@ -51,7 +51,7 @@ export default function ReminderForm({plantName, handleToggleModal, handleAddRem
                 </StyledFieldset>
                 <StyledButtonContainer>
                     <StyledSubmitButton type="submit">
-                        Create Reminder for {plantName}
+                        Create Reminder for {plant}
                     </StyledSubmitButton>
                 </StyledButtonContainer>
             </form>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -28,25 +28,25 @@ export default function App({ Component, pageProps }) {
       plantName: "TestPlant",
       task: "watering",
       date: "25.11.2024",
-      relatedPlant: 1
+      relatedPlant: "1"
     },
     { id: 2,
       plantName: "TestPlant2",
       task: "fertilizing",
       date: "25.11.2024",
-      relatedPlant: 2
+      relatedPlant: "2"
     },
     { id: 3,
       plantName: "TestPlant3",
       task: "fertilizing",
       date: "25.11.2024",
-      relatedPlant: 3
+      relatedPlant: "3"
     },
     { id: 4,
       plantName: "TestPlant4",
       task: "fertilizing",
       date: "25.11.2024",
-      relatedPlant: 4
+      relatedPlant: "4"
     }
   ];
 

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -23,6 +23,18 @@ export default function App({ Component, pageProps }) {
   const [progress, setProgress] = useState(100);
   const [isPaused, setIsPaused] = useState(false);
 
+
+  function getDate() {
+    const today = new Date();
+    const month = today.getMonth();
+    const year = today.getFullYear();
+    const date = today.getDate();
+    return `${year}-${month}-${date}`;
+  }
+
+  const [currentDate, setCurrentDate] = useState(getDate());
+
+
   const testReminder = [
     { id: 1,
       plantName: "Snake Plant",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -231,6 +231,11 @@ export default function App({ Component, pageProps }) {
     console.log(reminders);
   }
 
+  function handleDeleteReminder(id) {
+    setReminders((prevReminders) => prevReminders.filter((reminder) => reminder.id !== id));
+
+  }
+
   return (
     <>
       <GlobalStyle />

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -23,6 +23,15 @@ export default function App({ Component, pageProps }) {
   const [progress, setProgress] = useState(100);
   const [isPaused, setIsPaused] = useState(false);
 
+  const testReminder = [
+    { plantName: "TestPlant",
+      task: "watering",
+      date: "25.11.2024"
+    }
+  ];
+
+  const [reminders, setReminders] = useState(testReminder);
+
   const getRandomTip = () => {
     const randomIndex = Math.floor(Math.random() * tips.length);
     return tips[randomIndex];

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -25,25 +25,25 @@ export default function App({ Component, pageProps }) {
 
   const testReminder = [
     { id: 1,
-      plantName: "TestPlant",
+      plantName: "Snake Plant",
       task: "watering",
       date: "25.11.2024",
       relatedPlant: "1"
     },
     { id: 2,
-      plantName: "TestPlant2",
+      plantName: "Fiddle Leaf Fig",
       task: "fertilizing",
       date: "25.11.2024",
       relatedPlant: "2"
     },
     { id: 3,
-      plantName: "TestPlant3",
+      plantName: "Aloe Vera",
       task: "fertilizing",
       date: "25.11.2024",
       relatedPlant: "3"
     },
     { id: 4,
-      plantName: "TestPlant4",
+      plantName: "Spider Plant",
       task: "fertilizing",
       date: "25.11.2024",
       relatedPlant: "4"

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -28,6 +28,21 @@ export default function App({ Component, pageProps }) {
       plantName: "TestPlant",
       task: "watering",
       date: "25.11.2024"
+    },
+    { id: 2,
+      plantName: "TestPlant2",
+      task: "fertilizing",
+      date: "25.11.2024"
+    },
+    { id: 3,
+      plantName: "TestPlant3",
+      task: "fertilizing",
+      date: "25.11.2024"
+    },
+    { id: 4,
+      plantName: "TestPlant4",
+      task: "fertilizing",
+      date: "25.11.2024"
     }
   ];
 

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -231,9 +231,9 @@ export default function App({ Component, pageProps }) {
     console.log(reminders);
   }
 
-  function handleDeleteReminder(id) {
+  function handleDeleteReminder(id, task) {
     setReminders((prevReminders) => prevReminders.filter((reminder) => reminder.id !== id));
-    toast.success("Task completed");
+    toast.success(`${task} completed`);
   }
 
   return (

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -229,6 +229,7 @@ export default function App({ Component, pageProps }) {
         progress={progress}
         handleMouseHover={handleMouseHover}
         handleMouseLeave={handleMouseLeave}
+        reminders={reminders}
       />
       <Toaster/>
       <Navigation />

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -37,7 +37,6 @@ export default function App({ Component, pageProps }) {
   useEffect(() => {
     const Interval = setInterval(() => {
       setCurrentDate(getDate());
-      console.log(getDate());
     }, 10000);
 
     return () => clearInterval(Interval);
@@ -254,7 +253,6 @@ export default function App({ Component, pageProps }) {
     router.push(`/plants/${plantId}`);
     setIsReminder(false);
     setShowModal(false);
-    console.log(reminders);
   }
 
   function handleDeleteReminder(id, task) {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -24,7 +24,8 @@ export default function App({ Component, pageProps }) {
   const [isPaused, setIsPaused] = useState(false);
 
   const testReminder = [
-    { plantName: "TestPlant",
+    { id: 1,
+      plantName: "TestPlant",
       task: "watering",
       date: "25.11.2024"
     }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -218,15 +218,17 @@ export default function App({ Component, pageProps }) {
     setShowPlantFilterSection(!showPlantFilterSection);
   }
 
-  function handleAddReminder(newReminderData, id) {
+  function handleAddReminder(newReminderData, id, name) {
     const newReminder = {
-      ...newReminderData,
       id: nanoid(),
+      plantName: name,
+      ...newReminderData,
     };
     setReminders([newReminder, ...reminders]);
     router.push(`/plants/${id}`);
     setIsReminder(false);
     setShowModal(false);
+    console.log(reminders);
   }
 
   return (

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -26,7 +26,7 @@ export default function App({ Component, pageProps }) {
 
   function getDate() {
     const today = new Date();
-    const month = today.getMonth();
+    const month = today.getMonth() + 1;
     const year = today.getFullYear();
     const date = today.getDate();
     return `${year}-${month}-${date}`;
@@ -34,30 +34,39 @@ export default function App({ Component, pageProps }) {
 
   const [currentDate, setCurrentDate] = useState(getDate());
 
+  useEffect(() => {
+    const Interval = setInterval(() => {
+      setCurrentDate(getDate());
+      console.log(getDate());
+    }, 10000);
+
+    return () => clearInterval(Interval);
+  }, []);
+
 
   const testReminder = [
     { id: 1,
       plantName: "Snake Plant",
       task: "watering",
-      date: "25.11.2024",
+      date: "2024-11-25",
       relatedPlant: "1"
     },
     { id: 2,
       plantName: "Fiddle Leaf Fig",
       task: "fertilizing",
-      date: "25.11.2024",
+      date: "2024-11-25",
       relatedPlant: "2"
     },
     { id: 3,
       plantName: "Aloe Vera",
       task: "fertilizing",
-      date: "25.11.2024",
+      date: "2024-11-25",
       relatedPlant: "3"
     },
     { id: 4,
       plantName: "Spider Plant",
       task: "fertilizing",
-      date: "25.11.2024",
+      date: "2024-11-25",
       relatedPlant: "4"
     }
   ];
@@ -245,6 +254,7 @@ export default function App({ Component, pageProps }) {
     router.push(`/plants/${plantId}`);
     setIsReminder(false);
     setShowModal(false);
+    console.log(reminders);
   }
 
   function handleDeleteReminder(id, task) {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -288,7 +288,7 @@ export default function App({ Component, pageProps }) {
         handleDeleteReminder={handleDeleteReminder}
       />
       <Toaster/>
-      <Navigation />
+      <Navigation reminders={reminders} currentDate={currentDate}/>
     </>
   );
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -8,7 +8,7 @@ import { useRouter } from "next/router";
 import { nanoid } from "nanoid";
 import { useEffect, useState, useRef } from "react";
 import Navigation from "/components/Navigation";
-import { Toaster } from 'react-hot-toast';
+import toast, { Toaster } from 'react-hot-toast';
 import styled from "styled-components";
 
 export default function App({ Component, pageProps }) {
@@ -233,7 +233,7 @@ export default function App({ Component, pageProps }) {
 
   function handleDeleteReminder(id) {
     setReminders((prevReminders) => prevReminders.filter((reminder) => reminder.id !== id));
-
+    toast.success("Task completed");
   }
 
   return (

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -27,22 +27,26 @@ export default function App({ Component, pageProps }) {
     { id: 1,
       plantName: "TestPlant",
       task: "watering",
-      date: "25.11.2024"
+      date: "25.11.2024",
+      relatedPlant: 1
     },
     { id: 2,
       plantName: "TestPlant2",
       task: "fertilizing",
-      date: "25.11.2024"
+      date: "25.11.2024",
+      relatedPlant: 2
     },
     { id: 3,
       plantName: "TestPlant3",
       task: "fertilizing",
-      date: "25.11.2024"
+      date: "25.11.2024",
+      relatedPlant: 3
     },
     { id: 4,
       plantName: "TestPlant4",
       task: "fertilizing",
-      date: "25.11.2024"
+      date: "25.11.2024",
+      relatedPlant: 4
     }
   ];
 
@@ -218,17 +222,17 @@ export default function App({ Component, pageProps }) {
     setShowPlantFilterSection(!showPlantFilterSection);
   }
 
-  function handleAddReminder(newReminderData, id, name) {
+  function handleAddReminder(newReminderData, plantId, name) {
     const newReminder = {
       id: nanoid(),
       plantName: name,
+      relatedPlant: plantId,
       ...newReminderData,
     };
     setReminders([newReminder, ...reminders]);
-    router.push(`/plants/${id}`);
+    router.push(`/plants/${plantId}`);
     setIsReminder(false);
     setShowModal(false);
-    console.log(reminders);
   }
 
   function handleDeleteReminder(id, task) {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -269,6 +269,7 @@ export default function App({ Component, pageProps }) {
         reminders={reminders}
         isReminder={isReminder}
         handleAddReminder={handleAddReminder}
+        handleDeleteReminder={handleDeleteReminder}
       />
       <Toaster/>
       <Navigation />

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -218,6 +218,17 @@ export default function App({ Component, pageProps }) {
     setShowPlantFilterSection(!showPlantFilterSection);
   }
 
+  function handleAddReminder(newReminderData, id) {
+    const newReminder = {
+      ...newReminderData,
+      id: nanoid(),
+    };
+    setReminders([newReminder, ...reminders]);
+    router.push(`/plants/${id}`);
+    setIsReminder(false);
+    setShowModal(false);
+  }
+
   return (
     <>
       <GlobalStyle />
@@ -250,6 +261,7 @@ export default function App({ Component, pageProps }) {
         handleMouseLeave={handleMouseLeave}
         reminders={reminders}
         isReminder={isReminder}
+        handleAddReminder={handleAddReminder}
       />
       <Toaster/>
       <Navigation />

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -48,25 +48,25 @@ export default function App({ Component, pageProps }) {
     { id: 1,
       plantName: "Snake Plant",
       task: "watering",
-      date: "2024-11-25",
+      date: "2024-11-27",
       relatedPlant: "1"
     },
     { id: 2,
       plantName: "Fiddle Leaf Fig",
       task: "fertilizing",
-      date: "2024-11-25",
+      date: "2024-11-28",
       relatedPlant: "2"
     },
     { id: 3,
       plantName: "Aloe Vera",
       task: "fertilizing",
-      date: "2024-11-25",
+      date: "2024-11-30",
       relatedPlant: "3"
     },
     { id: 4,
       plantName: "Spider Plant",
       task: "fertilizing",
-      date: "2024-11-25",
+      date: "2024-12-03",
       relatedPlant: "4"
     }
   ];

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -84,6 +84,7 @@ export default function App({ Component, pageProps }) {
   const [showModal, setShowModal] = useState(false);
   const [isEdit, setIsEdit] = useState(false);
   const [isDelete, setIsDelete] = useState(false);
+  const [isReminder, setIsReminder] = useState(false);
 
   const initialFilterObject = {
     waterNeed: "",
@@ -144,6 +145,8 @@ export default function App({ Component, pageProps }) {
       setIsEdit(!isEdit);
     } else if (buttonFunctionText === "Delete") {
       setIsDelete(!isDelete);
+    } else if (buttonFunctionText === "Reminder") {
+      setIsReminder(!isReminder);
     }
   }
 
@@ -246,6 +249,7 @@ export default function App({ Component, pageProps }) {
         handleMouseHover={handleMouseHover}
         handleMouseLeave={handleMouseLeave}
         reminders={reminders}
+        isReminder={isReminder}
       />
       <Toaster/>
       <Navigation />

--- a/pages/plants/[id].js
+++ b/pages/plants/[id].js
@@ -14,7 +14,8 @@ export default function PlantDetailsPage({
   isOwned,
   handleToggleOwned,
   reminders,
-  isReminder
+  isReminder,
+  handleAddReminder
   }) {
   const router = useRouter();
 
@@ -45,6 +46,7 @@ export default function PlantDetailsPage({
         handleToggleOwned={handleToggleOwned}
         reminders={reminders}
         isReminder={isReminder}
+        handleAddReminder={handleAddReminder}
          />
     </main>
   );

--- a/pages/plants/[id].js
+++ b/pages/plants/[id].js
@@ -13,6 +13,7 @@ export default function PlantDetailsPage({
   tips,
   isOwned,
   handleToggleOwned,
+  reminders
   }) {
   const router = useRouter();
 
@@ -41,6 +42,7 @@ export default function PlantDetailsPage({
         tipsToBeTagged={tipsToBeTagged}
         isOwned={isOwned}
         handleToggleOwned={handleToggleOwned}
+        reminders={reminders}
          />
     </main>
   );

--- a/pages/plants/[id].js
+++ b/pages/plants/[id].js
@@ -15,7 +15,8 @@ export default function PlantDetailsPage({
   handleToggleOwned,
   reminders,
   isReminder,
-  handleAddReminder
+  handleAddReminder,
+  currentDate
   }) {
   const router = useRouter();
 
@@ -47,6 +48,7 @@ export default function PlantDetailsPage({
         reminders={reminders}
         isReminder={isReminder}
         handleAddReminder={handleAddReminder}
+        currentDate={currentDate}
          />
     </main>
   );

--- a/pages/plants/[id].js
+++ b/pages/plants/[id].js
@@ -13,7 +13,8 @@ export default function PlantDetailsPage({
   tips,
   isOwned,
   handleToggleOwned,
-  reminders
+  reminders,
+  isReminder
   }) {
   const router = useRouter();
 
@@ -43,6 +44,7 @@ export default function PlantDetailsPage({
         isOwned={isOwned}
         handleToggleOwned={handleToggleOwned}
         reminders={reminders}
+        isReminder={isReminder}
          />
     </main>
   );

--- a/pages/plants/[id].js
+++ b/pages/plants/[id].js
@@ -48,7 +48,6 @@ export default function PlantDetailsPage({
         reminders={reminders}
         isReminder={isReminder}
         handleAddReminder={handleAddReminder}
-        currentDate={currentDate}
          />
     </main>
   );

--- a/pages/remindersPage.js
+++ b/pages/remindersPage.js
@@ -1,9 +1,11 @@
-import ReminderCard from "@/components/ReminderCard";
+import styled from "styled-components";
+import ReminderCard from "/components/ReminderCard";
 
 export default function RemindersPage({reminders}) {
     return (
         <main>
-            <h1>Your reminders</h1>
+            <h1>Reminders</h1>
+            <StyledSpacer />
             <ul>
             {reminders.map((reminder) => 
                 <li key={reminder.id}>
@@ -13,3 +15,9 @@ export default function RemindersPage({reminders}) {
         </main>
     )
 }
+
+
+const StyledSpacer = styled.span`
+  display: block;
+  height: 113px;
+`;

--- a/pages/remindersPage.js
+++ b/pages/remindersPage.js
@@ -9,7 +9,7 @@ export default function RemindersPage({reminders, handleDeleteReminder}) {
             <ul>
             {reminders.map((reminder) => 
                 <li key={reminder.id}>
-                    <ReminderCard plantName={reminder.plantName} task={reminder.task} date={reminder.date} id={reminder.id} reminderPage={true} handleDeleteReminder={handleDeleteReminder} />
+                    <ReminderCard plantName={reminder.plantName} task={reminder.task} date={reminder.date} id={reminder.id} reminderPage={true} handleDeleteReminder={handleDeleteReminder} plantId={reminder.relatedPlant} />
                 </li>)}
             </ul>
         </main>

--- a/pages/remindersPage.js
+++ b/pages/remindersPage.js
@@ -7,7 +7,10 @@ export default function RemindersPage({reminders, handleDeleteReminder}) {
             <h1>Reminders</h1>
             <StyledSpacer />
             <ul>
-            {reminders.map((reminder) => 
+            {reminders.length === 0 && <StyledInfoText>Currently no reminders.</StyledInfoText>}
+            {reminders
+            .sort((a, b) => new Date(a.date) - new Date(b.date))
+            .map((reminder) => 
                 <li key={reminder.id}>
                     <ReminderCard plantName={reminder.plantName} task={reminder.task} date={reminder.date} id={reminder.id} reminderPage={true} handleDeleteReminder={handleDeleteReminder} plantId={reminder.relatedPlant} />
                 </li>)}
@@ -20,4 +23,12 @@ export default function RemindersPage({reminders, handleDeleteReminder}) {
 const StyledSpacer = styled.span`
   display: block;
   height: 113px;
+`;
+
+const StyledInfoText = styled.p`
+  color: var(--green-main);
+  background-color: var(--gray);
+  margin-top: 10px;
+  padding: 40px 40px;
+  border-radius: 25px;
 `;

--- a/pages/remindersPage.js
+++ b/pages/remindersPage.js
@@ -6,7 +6,7 @@ export default function RemindersPage({reminders}) {
             <h1>Your reminders</h1>
             <ul>
             {reminders.map((reminder) => 
-                <li key={reminder.plantName}>
+                <li key={reminder.id}>
                     <ReminderCard plantName={reminder.plantName} task={reminder.task} date={reminder.date} reminderPage={true} />
                 </li>)}
             </ul>

--- a/pages/remindersPage.js
+++ b/pages/remindersPage.js
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import ReminderCard from "/components/ReminderCard";
 
-export default function RemindersPage({reminders}) {
+export default function RemindersPage({reminders, handleDeleteReminder}) {
     return (
         <main>
             <h1>Reminders</h1>
@@ -9,7 +9,7 @@ export default function RemindersPage({reminders}) {
             <ul>
             {reminders.map((reminder) => 
                 <li key={reminder.id}>
-                    <ReminderCard plantName={reminder.plantName} task={reminder.task} date={reminder.date} reminderPage={true} />
+                    <ReminderCard plantName={reminder.plantName} task={reminder.task} date={reminder.date} reminderPage={true} handleDeleteReminder={handleDeleteReminder} />
                 </li>)}
             </ul>
         </main>

--- a/pages/remindersPage.js
+++ b/pages/remindersPage.js
@@ -10,8 +10,8 @@ export default function RemindersPage({reminders, handleDeleteReminder}) {
         <main>
             <h1>Reminders</h1>
             <StyledIconContainer onClick={() =>  router.back()} type="button">
-          <FaChevronLeft />
-        </StyledIconContainer>
+              <FaChevronLeft />
+            </StyledIconContainer>
             <StyledSpacer />
             <ul>
             {reminders.length === 0 && <StyledInfoText>Currently no reminders.</StyledInfoText>}
@@ -19,7 +19,14 @@ export default function RemindersPage({reminders, handleDeleteReminder}) {
             .sort((a, b) => new Date(a.date) - new Date(b.date))
             .map((reminder) => 
                 <li key={reminder.id}>
-                    <ReminderCard plantName={reminder.plantName} task={reminder.task} date={reminder.date} id={reminder.id} reminderPage={true} handleDeleteReminder={handleDeleteReminder} plantId={reminder.relatedPlant} />
+                    <ReminderCard 
+                    plantName={reminder.plantName} 
+                    task={reminder.task} 
+                    date={reminder.date} 
+                    id={reminder.id} 
+                    reminderPage={true} 
+                    handleDeleteReminder={handleDeleteReminder} 
+                    plantId={reminder.relatedPlant} />
                 </li>)}
             </ul>
         </main>

--- a/pages/remindersPage.js
+++ b/pages/remindersPage.js
@@ -9,7 +9,7 @@ export default function RemindersPage({reminders, handleDeleteReminder}) {
             <ul>
             {reminders.map((reminder) => 
                 <li key={reminder.id}>
-                    <ReminderCard plantName={reminder.plantName} task={reminder.task} date={reminder.date} reminderPage={true} handleDeleteReminder={handleDeleteReminder} />
+                    <ReminderCard plantName={reminder.plantName} task={reminder.task} date={reminder.date} id={reminder.id} reminderPage={true} handleDeleteReminder={handleDeleteReminder} />
                 </li>)}
             </ul>
         </main>

--- a/pages/remindersPage.js
+++ b/pages/remindersPage.js
@@ -1,10 +1,17 @@
 import styled from "styled-components";
 import ReminderCard from "/components/ReminderCard";
+import { FaChevronLeft } from "react-icons/fa6";
+import { useRouter } from "next/router";
 
 export default function RemindersPage({reminders, handleDeleteReminder}) {
+    const router = useRouter();
+
     return (
         <main>
             <h1>Reminders</h1>
+            <StyledIconContainer onClick={() =>  router.back()} type="button">
+          <FaChevronLeft />
+        </StyledIconContainer>
             <StyledSpacer />
             <ul>
             {reminders.length === 0 && <StyledInfoText>Currently no reminders.</StyledInfoText>}
@@ -22,7 +29,7 @@ export default function RemindersPage({reminders, handleDeleteReminder}) {
 
 const StyledSpacer = styled.span`
   display: block;
-  height: 113px;
+  height: 140px;
 `;
 
 const StyledInfoText = styled.p`
@@ -32,3 +39,19 @@ const StyledInfoText = styled.p`
   padding: 40px 40px;
   border-radius: 25px;
 `;
+
+const StyledIconContainer = styled.button `
+    background-color: var(--green-light);
+    border-radius: 40px;
+    border: none;
+    width: 50px;
+    height: 50px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: var(--white);
+    font-size: 30px;
+    position: absolute;
+    top: 70px;
+    left: 20px;
+ `;

--- a/pages/remindersPage.js
+++ b/pages/remindersPage.js
@@ -1,9 +1,15 @@
+import ReminderCard from "@/components/ReminderCard";
 
-export default function RemindersPage() {
+export default function RemindersPage({reminders}) {
     return (
         <main>
             <h1>Your reminders</h1>
-            <p>Hello World!</p>
+            <ul>
+            {reminders.map((reminder) => 
+                <li key={reminder.plantName}>
+                    <ReminderCard plantName={reminder.plantName} task={reminder.task} date={reminder.date} reminderPage={true} />
+                </li>)}
+            </ul>
         </main>
     )
 }

--- a/pages/remindersPage.js
+++ b/pages/remindersPage.js
@@ -1,0 +1,9 @@
+
+export default function RemindersPage() {
+    return (
+        <main>
+            <h1>Your reminders</h1>
+            <p>Hello World!</p>
+        </main>
+    )
+}


### PR DESCRIPTION
**Set custom reminders**
This feature enables users to set reminders for plant care tasks which they find either on the details page of a plant or on a separate reminders page for getting an overview of all reminders.

To achieve this, we:

- Implemented a page for "Reminders"
- Created a ReminderCard component
- Created a ReminderForm component
- Implemented a Button on PlantDetailsPage to add reminders
- Reused the Modal component to display and hide ReminderForm
- Implemented a notification icon which displays when reminders are set to the present date or are overdue
